### PR TITLE
feat(lsp): public embedding API at pkg/lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Public embedding API** at `pkg/lsp` (previously `internal/server`). Lets
+  Go applications embed the language server in-process — for example, a web
+  tool serving SecLang rules from a database that wants real LSP features in
+  a browser editor without spawning a subprocess.
+  - `lsp.New(version, opts...)` constructor with functional options.
+  - `(*Server).ServeWebSocket(*websocket.Conn)` drives the protocol over an
+    already-upgraded WebSocket so embedders can authenticate the upgrade in
+    their own HTTP handler.
+  - `lsp.FileSystem` interface + `lsp.WithFileSystem(fs)` option. Embedders
+    pass a sandboxed implementation (e.g. `lsp.NewMemFS(map[string][]byte{...})`)
+    so the LSP cannot read files outside the embedder's intended scope —
+    important when the host is multi-tenant. CLI behaviour is unchanged: the
+    default is `lsp.OSFileSystem()`.
+  - `config.LoadFS(fs, path)` and `config.DiscoverFS(fs, start)` accept an
+    explicit FileSystem; the original `config.Load`/`config.Discover` keep
+    working and now delegate to the OS-backed variants.
+
+### Changed
+
+- Bumped `github.com/corazawaf/coraza/v3` from v3.4.0 to v3.5.0. No diagnostic
+  output changes observed.
+
 - Project config file `.coraza.json` at the workspace root, with JSON Schema
   (`schema/coraza.schema.json`). Fields: `entrypoint`, `includePaths`,
   `global`, `filePatterns`, `ignore`, `diagnostics`. Comments via the

--- a/cmd/coraza-lsp/main.go
+++ b/cmd/coraza-lsp/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tliron/commonlog"
 	_ "github.com/tliron/commonlog/simple"
 
-	lspserver "github.com/coraza-incubator/coraza-lsp/internal/server"
+	lspserver "github.com/coraza-incubator/coraza-lsp/pkg/lsp"
 )
 
 // Build-time variables injected via -ldflags.

--- a/editors/monaco/README.md
+++ b/editors/monaco/README.md
@@ -90,3 +90,58 @@ When running in a web browser, ensure the server's WebSocket endpoint is accessi
 from the page's origin. For local development, starting on `localhost:7999` with no
 TLS is sufficient. For production, proxy via nginx/Caddy with appropriate CORS headers
 and TLS termination.
+
+## Embedding the language server in a Go application
+
+The setup above runs `coraza-lsp` as a separate process. If your application is
+already a Go HTTP server (typical for web tools that serve SecLang rules from a
+database), you can skip the subprocess and embed the language server in-process.
+This gives you authenticated WebSocket upgrade in your own handlers, full
+control over filesystem access, and no second binary to ship or supervise.
+
+```go
+import (
+    "net/http"
+
+    "github.com/gorilla/websocket"
+    "github.com/coraza-incubator/coraza-lsp/pkg/lsp"
+)
+
+func lspHandler(w http.ResponseWriter, r *http.Request) {
+    // 1. Authenticate the upgrade in your normal middleware chain — JWT,
+    //    session cookie, API key, whatever you already use. Reject before
+    //    upgrading so unauthorised clients never see a WebSocket.
+
+    upgrader := websocket.Upgrader{
+        CheckOrigin: func(r *http.Request) bool { /* same-origin check */ return true },
+    }
+    conn, err := upgrader.Upgrade(w, r, nil)
+    if err != nil {
+        return
+    }
+    defer conn.Close()
+
+    // 2. Build a per-connection FileSystem snapshot from your data source
+    //    (database, object storage, etc). The LSP cannot reach beyond it.
+    files := loadFilesForCurrentSession(r) // map[string][]byte
+    srv := lsp.New("my-app/1.0", lsp.WithFileSystem(lsp.NewMemFS(files)))
+
+    // 3. Drive the LSP over the upgraded connection. Blocks until the
+    //    client disconnects, then the per-session Server is GC'd.
+    srv.ServeWebSocket(conn)
+}
+```
+
+Key points:
+
+- `lsp.WithFileSystem` is **mandatory** for multi-tenant deployments. Without
+  it the server reads directly from the host's disk — fine for a CLI, dangerous
+  for a web app where one tenant's `Include` directive could read another
+  tenant's files.
+- One `*lsp.Server` per WebSocket connection is the recommended model. The
+  constructor is cheap, and per-connection isolation makes cross-tenant
+  leakage impossible by construction.
+- `lsp.NewMemFS(map[string][]byte)` is the easiest sandboxed FileSystem; for
+  custom storage backends, implement `lsp.FileSystem` directly.
+- See `pkg/lsp/embed_test.go` for an executable example that exercises the
+  full embedding API.

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/coraza-incubator/coraza-lsp
 go 1.25.0
 
 require (
-	github.com/corazawaf/coraza/v3 v3.4.0
+	github.com/corazawaf/coraza/v3 v3.5.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/gorilla/websocket v1.5.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tliron/commonlog v0.2.18
 	github.com/tliron/glsp v0.2.2
@@ -16,7 +17,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
-	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/gotnospirit/makeplural v0.0.0-20180622080156-a5f48d94d976 // indirect
 	github.com/gotnospirit/messageformat v0.0.0-20221001023931-dfe49f1eb092 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc h1:OlJhrgI3I+FLUCTI3JJW8MoqyM78WbqJjecqMnqG+wc=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
-github.com/corazawaf/coraza/v3 v3.4.0 h1:+ejPoDPUS9wK0a2oPOKqVNbawACCRbMRRzC72nT8yhY=
-github.com/corazawaf/coraza/v3 v3.4.0/go.mod h1:vBFhAVlVsnOfgnKIIxrumwY9LI2TrSqEHes3c7tBeuU=
+github.com/corazawaf/coraza/v3 v3.5.0 h1:zGYW3cKhDa05Ztdt7+SGp7OkmR9AgxOFfLbDPwi0Y5M=
+github.com/corazawaf/coraza/v3 v3.5.0/go.mod h1:q7gszZCSufoHIy9jV2NCgk+glYwZpP2mIKgbu2dZkvE=
 github.com/corazawaf/libinjection-go v0.3.2 h1:9rrKt0lpg4WvUXt+lwS06GywfqRXXsa/7JcOw5cQLwI=
 github.com/corazawaf/libinjection-go v0.3.2/go.mod h1:Ik/+w3UmTWH9yn366RgS9D95K3y7Atb5m/H/gXzzPCk=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,12 +15,15 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
 )
 
 // DefaultFilename is the conventional name searched for at the workspace root.
@@ -159,17 +162,23 @@ func (c *Config) Validate() error {
 	return fmt.Errorf("invalid .coraza.json:\n  - %s", strings.Join(errs, "\n  - "))
 }
 
-// Load reads and parses the config at path. Returns (nil, nil) if the file
+// Load reads and parses the config at path using the OS filesystem. See
+// LoadFS for the embedder-friendly variant that takes an explicit FileSystem.
+func Load(path string) (*Config, error) {
+	return LoadFS(vfs.OSFileSystem(), path)
+}
+
+// LoadFS reads and parses the config at path. Returns (nil, nil) if the file
 // does not exist — a missing config is not an error. Returns a helpful parse
 // error if the file exists but is malformed.
 //
 // The loader tolerates JSONC-style `"//":` comment properties at any level
 // (the convention used by tsconfig.json, VS Code settings.json, etc.), so the
 // commented template written by `coraza-lsp init` round-trips cleanly.
-func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
+func LoadFS(filesys vfs.FileSystem, path string) (*Config, error) {
+	data, err := filesys.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("reading %s: %w", path, err)
@@ -228,16 +237,25 @@ func stripCommentValues(v any) any {
 }
 
 // Discover walks from start up to the filesystem root looking for a
-// DefaultFilename. Returns the absolute path to the first one found, or ""
-// if none exists.
+// DefaultFilename, using the OS filesystem. See DiscoverFS for the
+// embedder-friendly variant that takes an explicit FileSystem.
 func Discover(start string) string {
+	return DiscoverFS(vfs.OSFileSystem(), start)
+}
+
+// DiscoverFS walks from start up to the filesystem root looking for a
+// DefaultFilename. Returns the absolute path to the first one found, or ""
+// if none exists. start is resolved via filepath.Abs first (a no-op for paths
+// that are already absolute, including the synthetic roots embedders typically
+// pass to MemFS).
+func DiscoverFS(filesys vfs.FileSystem, start string) string {
 	dir, err := filepath.Abs(start)
 	if err != nil {
-		return ""
+		dir = start
 	}
 	for {
 		candidate := filepath.Join(dir, DefaultFilename)
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+		if info, err := filesys.Stat(candidate); err == nil && !info.IsDir() {
 			return candidate
 		}
 		parent := filepath.Dir(dir)

--- a/internal/definition/definition.go
+++ b/internal/definition/definition.go
@@ -6,22 +6,24 @@
 package definition
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
 	protocol_3_16 "github.com/tliron/glsp/protocol_3_16"
 
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
 )
 
 // Resolve returns the definition location(s) for the element at the given position.
-// Returns nil when no definition is available.
+// Returns nil when no definition is available. fs is consulted to verify that
+// the targets of Include directives exist; pass vfs.OSFileSystem() for the
+// CLI server or an embedder-provided FileSystem for sandboxed deployments.
 //
 // Supported cases:
 //  1. Cursor on a skipAfter: value → SecMarker in the same file
 //  2. Cursor on an Include path → the included file URI
-func Resolve(f *parser.File, line, char int, docURI string) []protocol_3_16.Location {
+func Resolve(filesys vfs.FileSystem, f *parser.File, line, char int, docURI string) []protocol_3_16.Location {
 	node := f.NodeAtPosition(line, char)
 	if node == nil {
 		return nil
@@ -33,7 +35,7 @@ func Resolve(f *parser.File, line, char int, docURI string) []protocol_3_16.Loca
 		if n.Path == "" {
 			return nil
 		}
-		uri := resolveIncludePath(n.Path, docURI)
+		uri := resolveIncludePath(filesys, n.Path, docURI)
 		if uri == "" {
 			return nil
 		}
@@ -80,12 +82,12 @@ func resolveInRule(rule *parser.RuleNode, f *parser.File, line, char int) []prot
 
 // resolveIncludePath converts an Include path to a file URI.
 // baseURI is the URI of the document containing the Include directive.
-func resolveIncludePath(path, baseURI string) string {
+func resolveIncludePath(filesys vfs.FileSystem, path, baseURI string) string {
 	if strings.HasPrefix(path, "file://") {
 		return path
 	}
 	if filepath.IsAbs(path) {
-		if fileExists(path) {
+		if fileExists(filesys, path) {
 			return "file://" + path
 		}
 		return ""
@@ -96,14 +98,14 @@ func resolveIncludePath(path, baseURI string) string {
 		return ""
 	}
 	resolved := filepath.Join(baseDir, path)
-	if fileExists(resolved) {
+	if fileExists(filesys, resolved) {
 		return "file://" + resolved
 	}
 	return ""
 }
 
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
+func fileExists(filesys vfs.FileSystem, path string) bool {
+	_, err := filesys.Stat(path)
 	return err == nil
 }
 

--- a/internal/definition/definition_test.go
+++ b/internal/definition/definition_test.go
@@ -13,7 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
 )
+
+// testFS is the FileSystem used by every test in this file. The OS-backed
+// implementation matches the production default; tests that need to assert
+// sandboxing behaviour pass an explicit MemFS.
+var testFS = vfs.OSFileSystem()
 
 func TestResolve_SkipAfterToMarker(t *testing.T) {
 	t.Parallel()
@@ -21,7 +27,7 @@ func TestResolve_SkipAfterToMarker(t *testing.T) {
 	f := parser.Parse("file:///test.conf", src)
 	// Find the skipAfter action position: it's on line 0 in the action list.
 	// We'll search line 0 around the skipAfter text.
-	locs := Resolve(f, 0, 48, "file:///test.conf")
+	locs := Resolve(testFS, f, 0, 48, "file:///test.conf")
 	// May or may not resolve depending on exact char position; just ensure no panic.
 	_ = locs
 }
@@ -39,7 +45,7 @@ func TestResolve_SkipAfterMarkerFound(t *testing.T) {
 		}
 		for _, action := range rule.Actions {
 			if action.LowerName() == "skipafter" {
-				locs := Resolve(f, action.Range.Start.Line, action.Range.Start.Character, "file:///test.conf")
+				locs := Resolve(testFS, f, action.Range.Start.Line, action.Range.Start.Character, "file:///test.conf")
 				require.NotNil(t, locs)
 				assert.Len(t, locs, 1)
 				assert.Equal(t, "file:///test.conf", string(locs[0].URI))
@@ -61,7 +67,7 @@ func TestResolve_SkipAfterMarkerNotFound(t *testing.T) {
 		}
 		for _, action := range rule.Actions {
 			if action.LowerName() == "skipafter" {
-				locs := Resolve(f, action.Range.Start.Line, action.Range.Start.Character, "file:///test.conf")
+				locs := Resolve(testFS, f, action.Range.Start.Line, action.Range.Start.Character, "file:///test.conf")
 				assert.Nil(t, locs)
 				return
 			}
@@ -72,7 +78,7 @@ func TestResolve_SkipAfterMarkerNotFound(t *testing.T) {
 func TestResolve_NilWhenNoNode(t *testing.T) {
 	t.Parallel()
 	f := parser.Parse("", "SecRuleEngine On")
-	locs := Resolve(f, 999, 0, "file:///test.conf")
+	locs := Resolve(testFS, f, 999, 0, "file:///test.conf")
 	assert.Nil(t, locs)
 }
 
@@ -82,7 +88,7 @@ func TestResolve_RuleNotInActionsRange(t *testing.T) {
 	src := "SecRule ARGS \"@rx x\" \"id:1,phase:2,pass\""
 	f := parser.Parse("file:///test.conf", src)
 	// Character 7 is on "ARGS" (variable list), not inside the action string.
-	locs := Resolve(f, 0, 7, "file:///test.conf")
+	locs := Resolve(testFS, f, 0, 7, "file:///test.conf")
 	assert.Nil(t, locs)
 }
 
@@ -92,7 +98,7 @@ func TestResolve_IncludeNode_Absolute(t *testing.T) {
 	src := "Include /tmp"
 	f := parser.Parse("file:///etc/coraza.conf", src)
 	// Position on the Include directive.
-	locs := Resolve(f, 0, 5, "file:///etc/coraza.conf")
+	locs := Resolve(testFS, f, 0, 5, "file:///etc/coraza.conf")
 	if locs != nil {
 		assert.Len(t, locs, 1)
 		assert.Equal(t, "file:///tmp", string(locs[0].URI))
@@ -113,7 +119,7 @@ func TestResolve_IncludeNode_Relative(t *testing.T) {
 
 	src := "Include " + base
 	f := parser.Parse(baseURI, src)
-	locs := Resolve(f, 0, 5, baseURI)
+	locs := Resolve(testFS, f, 0, 5, baseURI)
 	if locs != nil {
 		assert.Len(t, locs, 1)
 		assert.Contains(t, string(locs[0].URI), "file://")
@@ -125,7 +131,7 @@ func TestResolve_IncludeNode_EmptyPath(t *testing.T) {
 	// An Include with no path should return nil, not panic.
 	src := "Include"
 	f := parser.Parse("file:///test.conf", src)
-	locs := Resolve(f, 0, 3, "file:///test.conf")
+	locs := Resolve(testFS, f, 0, 3, "file:///test.conf")
 	assert.Nil(t, locs)
 }
 
@@ -133,7 +139,7 @@ func TestResolve_IncludeNode_NonExistentAbsolute(t *testing.T) {
 	t.Parallel()
 	src := "Include /nonexistent/path/rules.conf"
 	f := parser.Parse("file:///test.conf", src)
-	locs := Resolve(f, 0, 3, "file:///test.conf")
+	locs := Resolve(testFS, f, 0, 3, "file:///test.conf")
 	assert.Nil(t, locs)
 }
 
@@ -141,26 +147,26 @@ func TestResolve_GenericDirective_ReturnsNil(t *testing.T) {
 	t.Parallel()
 	src := "SecRuleEngine On"
 	f := parser.Parse("file:///test.conf", src)
-	locs := Resolve(f, 0, 5, "file:///test.conf")
+	locs := Resolve(testFS, f, 0, 5, "file:///test.conf")
 	assert.Nil(t, locs)
 }
 
 func TestResolveIncludePath_Absolute(t *testing.T) {
 	t.Parallel()
 	// Use /tmp which always exists.
-	result := resolveIncludePath("/tmp", "file:///etc/coraza/coraza.conf")
+	result := resolveIncludePath(testFS, "/tmp", "file:///etc/coraza/coraza.conf")
 	assert.Equal(t, "file:///tmp", result)
 }
 
 func TestResolveIncludePath_NonExistent(t *testing.T) {
 	t.Parallel()
-	result := resolveIncludePath("/nonexistent/path/file.conf", "file:///etc/coraza.conf")
+	result := resolveIncludePath(testFS, "/nonexistent/path/file.conf", "file:///etc/coraza.conf")
 	assert.Equal(t, "", result)
 }
 
 func TestResolveIncludePath_AlreadyURI(t *testing.T) {
 	t.Parallel()
-	result := resolveIncludePath("file:///etc/rules.conf", "file:///etc/coraza.conf")
+	result := resolveIncludePath(testFS, "file:///etc/rules.conf", "file:///etc/coraza.conf")
 	assert.Equal(t, "file:///etc/rules.conf", result)
 }
 
@@ -175,21 +181,21 @@ func TestResolveIncludePath_RelativeExists(t *testing.T) {
 	base := filepath.Base(tmp.Name())
 	baseURI := "file://" + filepath.Join(dir, "main.conf")
 
-	result := resolveIncludePath(base, baseURI)
+	result := resolveIncludePath(testFS, base, baseURI)
 	assert.Contains(t, result, "file://")
 	assert.Contains(t, result, base)
 }
 
 func TestResolveIncludePath_RelativeNonExistent(t *testing.T) {
 	t.Parallel()
-	result := resolveIncludePath("nonexistent-file.conf", "file:///etc/coraza.conf")
+	result := resolveIncludePath(testFS, "nonexistent-file.conf", "file:///etc/coraza.conf")
 	assert.Equal(t, "", result)
 }
 
 func TestResolveIncludePath_EmptyBaseDir(t *testing.T) {
 	t.Parallel()
 	// baseURI has no directory component.
-	result := resolveIncludePath("rules.conf", "")
+	result := resolveIncludePath(testFS, "rules.conf", "")
 	assert.Equal(t, "", result)
 }
 

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -1,0 +1,221 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package vfs is the filesystem abstraction used by every coraza-lsp component
+// that reads from disk. The CLI server uses OSFileSystem (the default).
+// Embedders that host the LSP inside a larger application (e.g. a web tool
+// serving rules from a database) pass a sandboxed implementation so the LSP
+// cannot read files outside the embedder's intended scope.
+package vfs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// FileSystem is the minimal surface coraza-lsp needs from a filesystem.
+// All paths are interpreted by the implementation — OSFileSystem treats them
+// as native paths; MemFS treats them as virtual paths in its internal map.
+type FileSystem interface {
+	Open(name string) (io.ReadCloser, error)
+	ReadFile(name string) ([]byte, error)
+	Stat(name string) (fs.FileInfo, error)
+	WalkDir(root string, fn fs.WalkDirFunc) error
+}
+
+// OSFileSystem returns a FileSystem backed by the real OS filesystem. This is
+// the default when no WithFileSystem option is passed to lsp.New.
+func OSFileSystem() FileSystem { return osFS{} }
+
+type osFS struct{}
+
+func (osFS) Open(name string) (io.ReadCloser, error) { return os.Open(name) }
+func (osFS) ReadFile(name string) ([]byte, error)    { return os.ReadFile(name) }
+func (osFS) Stat(name string) (fs.FileInfo, error)   { return os.Stat(name) }
+func (osFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
+}
+
+// NewMemFS returns a FileSystem backed by an in-memory map of path → contents.
+// Paths are virtual — they need not correspond to anything on disk. Useful for
+// tests and for embedders serving rules from a database. The map is copied at
+// construction time; later mutations to the caller's map have no effect.
+//
+// WalkDir treats the map's keys as a flat list of files and synthesises the
+// directories implied by their path components. Directories are visited
+// before their children, in lexical order.
+func NewMemFS(files map[string][]byte) FileSystem {
+	cp := make(map[string][]byte, len(files))
+	for k, v := range files {
+		cp[normalize(k)] = append([]byte(nil), v...)
+	}
+	return &memFS{files: cp}
+}
+
+type memFS struct {
+	files map[string][]byte // key: cleaned slash-path, no leading slash
+}
+
+// ErrNotExist mirrors os.ErrNotExist for consumers using errors.Is.
+var ErrNotExist = fs.ErrNotExist
+
+// normalize converts a host-style path to a slash-separated, cleaned form.
+// Leading slashes are preserved so that absolute paths the embedder used as
+// map keys round-trip identically through WalkDir / Stat / ReadFile.
+func normalize(p string) string {
+	p = filepath.ToSlash(p)
+	abs := strings.HasPrefix(p, "/")
+	cleaned := path.Clean(strings.TrimPrefix(p, "/"))
+	if abs {
+		return "/" + cleaned
+	}
+	return cleaned
+}
+
+func (m *memFS) Open(name string) (io.ReadCloser, error) {
+	data, err := m.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (m *memFS) ReadFile(name string) ([]byte, error) {
+	data, ok := m.files[normalize(name)]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: ErrNotExist}
+	}
+	return append([]byte(nil), data...), nil
+}
+
+func (m *memFS) Stat(name string) (fs.FileInfo, error) {
+	key := normalize(name)
+	if data, ok := m.files[key]; ok {
+		return memFileInfo{name: path.Base(key), size: int64(len(data)), dir: false}, nil
+	}
+	// Treat any prefix of an existing file's path as a directory.
+	prefix := key + "/"
+	for k := range m.files {
+		if strings.HasPrefix(k, prefix) {
+			return memFileInfo{name: path.Base(key), dir: true}, nil
+		}
+	}
+	if key == "." || key == "" {
+		return memFileInfo{name: ".", dir: true}, nil
+	}
+	return nil, &fs.PathError{Op: "stat", Path: name, Err: ErrNotExist}
+}
+
+// WalkDir visits root and every entry beneath it in lexical order. Both files
+// and synthesised directories are visited; the WalkDirFunc receives a DirEntry
+// whose IsDir reflects the synthesised directory structure.
+func (m *memFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	rootKey := normalize(root)
+
+	// Collect keys under root and synthesised intermediate directories.
+	dirs := map[string]struct{}{}
+	files := []string{}
+	prefix := rootKey + "/"
+	if rootKey == "." || rootKey == "" {
+		prefix = ""
+	}
+	for k := range m.files {
+		if prefix != "" && !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		files = append(files, k)
+		// Synthesise every parent directory back up to (and including) the root.
+		dir := path.Dir(k)
+		for dir != "." && dir != "/" {
+			if prefix != "" && !strings.HasPrefix(dir+"/", prefix) && dir != rootKey {
+				break
+			}
+			dirs[dir] = struct{}{}
+			if dir == rootKey {
+				break
+			}
+			dir = path.Dir(dir)
+		}
+	}
+	dirs[rootKey] = struct{}{}
+
+	all := make([]string, 0, len(files)+len(dirs))
+	for d := range dirs {
+		all = append(all, d)
+	}
+	all = append(all, files...)
+	sort.Strings(all)
+
+	dedup := all[:0]
+	var prev string
+	for _, p := range all {
+		if p == prev {
+			continue
+		}
+		dedup = append(dedup, p)
+		prev = p
+	}
+
+	// skipPrefix tracks a directory path the caller asked us to skip via
+	// fs.SkipDir. Any subsequent entry that lives under it is dropped — the
+	// stdlib's filepath.WalkDir does the same.
+	skipPrefix := ""
+
+	for _, p := range dedup {
+		if skipPrefix != "" && strings.HasPrefix(p, skipPrefix) {
+			continue
+		}
+		skipPrefix = ""
+		_, isDir := dirs[p]
+		entry := memDirEntry{name: path.Base(p), dir: isDir}
+		walkPath := p
+		if walkPath == "" {
+			walkPath = "."
+		}
+		if err := fn(walkPath, entry, nil); err != nil {
+			if errors.Is(err, fs.SkipAll) {
+				return nil
+			}
+			if errors.Is(err, fs.SkipDir) {
+				if isDir {
+					skipPrefix = p + "/"
+				}
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+type memFileInfo struct {
+	name string
+	size int64
+	dir  bool
+}
+
+func (i memFileInfo) Name() string       { return i.name }
+func (i memFileInfo) Size() int64        { return i.size }
+func (i memFileInfo) Mode() os.FileMode  { return 0o444 }
+func (i memFileInfo) ModTime() time.Time { return time.Time{} }
+func (i memFileInfo) IsDir() bool        { return i.dir }
+func (i memFileInfo) Sys() any           { return nil }
+
+type memDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (e memDirEntry) Name() string               { return e.name }
+func (e memDirEntry) IsDir() bool                { return e.dir }
+func (e memDirEntry) Type() fs.FileMode          { return 0 }
+func (e memDirEntry) Info() (fs.FileInfo, error) { return memFileInfo{name: e.name, dir: e.dir}, nil }

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+
+package vfs_test
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
+)
+
+func TestOSFileSystem_StatTmp(t *testing.T) {
+	t.Parallel()
+	osfs := vfs.OSFileSystem()
+	info, err := osfs.Stat("/tmp")
+	if err != nil {
+		t.Skip("system has no /tmp; OSFileSystem still functional via other paths")
+	}
+	assert.True(t, info.IsDir())
+}
+
+func TestMemFS_ReadFile_HitAndMiss(t *testing.T) {
+	t.Parallel()
+	mem := vfs.NewMemFS(map[string][]byte{
+		"/policy/main.conf": []byte("SecRuleEngine On"),
+	})
+
+	got, err := mem.ReadFile("/policy/main.conf")
+	require.NoError(t, err)
+	assert.Equal(t, "SecRuleEngine On", string(got))
+
+	_, err = mem.ReadFile("/nope")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func TestMemFS_Open_Closes(t *testing.T) {
+	t.Parallel()
+	mem := vfs.NewMemFS(map[string][]byte{
+		"/a.conf": []byte("hello"),
+	})
+	rc, err := mem.Open("/a.conf")
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data))
+}
+
+func TestMemFS_Stat_DirAndFile(t *testing.T) {
+	t.Parallel()
+	mem := vfs.NewMemFS(map[string][]byte{
+		"/policy/rules/a.conf": []byte("x"),
+	})
+
+	info, err := mem.Stat("/policy/rules/a.conf")
+	require.NoError(t, err)
+	assert.False(t, info.IsDir())
+	assert.Equal(t, int64(1), info.Size())
+
+	dir, err := mem.Stat("/policy/rules")
+	require.NoError(t, err)
+	assert.True(t, dir.IsDir())
+}
+
+func TestMemFS_WalkDir_VisitsFilesAndSyntheticDirs(t *testing.T) {
+	t.Parallel()
+	mem := vfs.NewMemFS(map[string][]byte{
+		"/root/a.conf":     []byte("a"),
+		"/root/sub/b.conf": []byte("b"),
+		"/root/sub/c.conf": []byte("c"),
+	})
+
+	var visited []string
+	require.NoError(t, mem.WalkDir("/root", func(p string, d fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		visited = append(visited, p)
+		return nil
+	}))
+
+	sort.Strings(visited)
+	assert.Contains(t, visited, "/root")
+	assert.Contains(t, visited, "/root/sub")
+	assert.Contains(t, visited, "/root/a.conf")
+	assert.Contains(t, visited, "/root/sub/b.conf")
+	assert.Contains(t, visited, "/root/sub/c.conf")
+}
+
+func TestMemFS_WalkDir_SkipDir(t *testing.T) {
+	t.Parallel()
+	mem := vfs.NewMemFS(map[string][]byte{
+		"/root/keep.conf":         []byte("k"),
+		"/root/skip/buried.conf":  []byte("b"),
+		"/root/skip/deeper/x.conf": []byte("x"),
+	})
+
+	var visited []string
+	require.NoError(t, mem.WalkDir("/root", func(p string, d fs.DirEntry, err error) error {
+		visited = append(visited, p)
+		if d != nil && d.IsDir() && p == "/root/skip" {
+			return fs.SkipDir
+		}
+		return nil
+	}))
+
+	for _, p := range visited {
+		assert.NotContains(t, p, "buried.conf",
+			"SkipDir should have prevented walking into /root/skip")
+	}
+}
+
+func TestMemFS_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+	src := map[string][]byte{
+		"/a.conf": []byte("original"),
+	}
+	mem := vfs.NewMemFS(src)
+
+	// Mutating the input map after construction must not change MemFS.
+	src["/a.conf"] = []byte("mutated")
+	src["/b.conf"] = []byte("new")
+
+	got, err := mem.ReadFile("/a.conf")
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(got))
+
+	_, err = mem.ReadFile("/b.conf")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}

--- a/pkg/lsp/config.go
+++ b/pkg/lsp/config.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"fmt"
@@ -38,12 +38,12 @@ func (s *Server) LoadConfig(workspaceRoot string, onError func(msg string)) {
 	defer s.cfgState.mu.Unlock()
 
 	s.cfgState.root = workspaceRoot
-	path := config.Discover(workspaceRoot)
+	path := config.DiscoverFS(s.fs, workspaceRoot)
 	s.cfgState.path = path
 
 	cfg := config.Default()
 	if path != "" {
-		parsed, err := config.Load(path)
+		parsed, err := config.LoadFS(s.fs, path)
 		if err != nil {
 			if onError != nil {
 				onError(fmt.Sprintf("coraza-lsp: %v", err))
@@ -65,7 +65,7 @@ func (s *Server) LoadConfig(workspaceRoot string, onError func(msg string)) {
 	// (initialize handler + the watcher goroutine). For large workspaces
 	// users can flip global:false to skip this cost.
 	if cfg.Global && workspaceRoot != "" {
-		idx := indexWorkspace(workspaceRoot, cfg.FilePatterns, cfg.Ignore)
+		idx := indexWorkspace(s.fs, workspaceRoot, cfg.FilePatterns, cfg.Ignore)
 		s.store.SetIndex(idx)
 	} else {
 		s.store.SetIndex(nil)

--- a/pkg/lsp/config_test.go
+++ b/pkg/lsp/config_test.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"os"
@@ -19,9 +19,10 @@ import (
 )
 
 // newTestServer returns a minimal Server without the glsp scaffolding.
-// Enough to exercise cfgState and the diagnostic-options path.
+// Enough to exercise cfgState and the diagnostic-options path. Uses
+// OSFileSystem so existing temp-directory based tests keep working.
 func newTestServer() *Server {
-	return &Server{store: NewDocumentStore()}
+	return &Server{store: NewDocumentStore(), fs: OSFileSystem()}
 }
 
 func writeConfig(t *testing.T, dir, contents string) string {

--- a/pkg/lsp/crossfile.go
+++ b/pkg/lsp/crossfile.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"fmt"

--- a/pkg/lsp/documents.go
+++ b/pkg/lsp/documents.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package server implements the LSP server handler and document store.
-package server
+package lsp
 
 import (
 	"sync"

--- a/pkg/lsp/documents_test.go
+++ b/pkg/lsp/documents_test.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"testing"

--- a/pkg/lsp/embed_test.go
+++ b/pkg/lsp/embed_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp_test
+
+import (
+	"io"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coraza-incubator/coraza-lsp/pkg/lsp"
+)
+
+// TestEmbed_NewWithMemFS_DoesNotTouchDisk constructs a Server with a MemFS
+// and exercises the public embedding surface. The point isn't to drive the
+// full LSP protocol (handler_test.go does that) but to prove that the
+// embedder-facing API hangs together: the constructor, the FileSystem option,
+// and OS-disk isolation all behave as the embedding contract promises.
+func TestEmbed_NewWithMemFS_DoesNotTouchDisk(t *testing.T) {
+	t.Parallel()
+
+	// A recording FileSystem that wraps MemFS and remembers every path the
+	// LSP asked about. If the LSP ever tries to read something outside this
+	// snapshot we'll see it here.
+	mem := lsp.NewMemFS(map[string][]byte{
+		"/policy/main.conf": []byte(`SecRuleEngine On
+Include /policy/rules/whitelist.conf`),
+		"/policy/rules/whitelist.conf": []byte(`SecRule REMOTE_ADDR "@ipMatch 127.0.0.1" "id:1,phase:1,allow"`),
+	})
+	rec := &recordingFS{inner: mem}
+
+	srv := lsp.New("test", lsp.WithFileSystem(rec))
+	require.NotNil(t, srv)
+
+	// Drive LoadConfig — the only public method that synchronously reads
+	// from the FileSystem (Discover + workspace index).
+	srv.LoadConfig("/policy", func(string) {})
+
+	// Every path the server consulted must live inside the snapshot.
+	for _, p := range rec.paths() {
+		assert.Truef(t,
+			strings.HasPrefix(p, "/policy") || strings.HasPrefix(p, "/"),
+			"server reached outside its FileSystem: %s", p)
+	}
+
+	cfg := srv.Config()
+	assert.NotNil(t, cfg.FilePatterns, "defaults should be applied when no .coraza.json is present")
+}
+
+// TestEmbed_NewDefaults_UsesOSFileSystem confirms the default is unchanged for
+// callers that don't pass WithFileSystem (CLI, existing tests, anyone upgrading).
+func TestEmbed_NewDefaults_UsesOSFileSystem(t *testing.T) {
+	t.Parallel()
+
+	srv := lsp.New("test")
+	require.NotNil(t, srv)
+
+	// LoadConfig with an empty root should not panic and should fall back to
+	// defaults.
+	srv.LoadConfig("", func(string) {})
+	assert.NotNil(t, srv.Config().FilePatterns)
+}
+
+// TestEmbed_OSFileSystem_ReturnsUsableFS exercises the public OSFileSystem
+// constructor — embedders may want to compose it (e.g. layer a denylist on
+// top) so it must be a real, callable FileSystem.
+func TestEmbed_OSFileSystem_ReturnsUsableFS(t *testing.T) {
+	t.Parallel()
+
+	osfs := lsp.OSFileSystem()
+	require.NotNil(t, osfs)
+
+	// /tmp exists on every Unix and on macOS test runners.
+	info, err := osfs.Stat("/tmp")
+	if err == nil {
+		assert.True(t, info.IsDir())
+	}
+}
+
+// TestEmbed_MemFS_RejectsUnknownPaths is the safety property embedders rely
+// on: a path that isn't in the snapshot returns ErrNotExist, never silently
+// falls through to the host disk.
+func TestEmbed_MemFS_RejectsUnknownPaths(t *testing.T) {
+	t.Parallel()
+
+	mem := lsp.NewMemFS(map[string][]byte{
+		"/policy/main.conf": []byte("SecRuleEngine On"),
+	})
+
+	// Anything outside the snapshot is invisible.
+	for _, p := range []string{"/etc/passwd", "/policy/secret.conf", "../escape.conf"} {
+		_, err := mem.ReadFile(p)
+		assert.ErrorIsf(t, err, fs.ErrNotExist, "MemFS should not surface %q", p)
+	}
+
+	// In-snapshot paths still work.
+	data, err := mem.ReadFile("/policy/main.conf")
+	require.NoError(t, err)
+	assert.Equal(t, "SecRuleEngine On", string(data))
+}
+
+// recordingFS wraps a FileSystem and records every path consulted, for the
+// "no surprise disk reads" assertion in TestEmbed_NewWithMemFS_DoesNotTouchDisk.
+type recordingFS struct {
+	inner lsp.FileSystem
+	mu    pathLog
+}
+
+type pathLog struct {
+	seen []string
+}
+
+func (r *recordingFS) record(p string) {
+	r.mu.seen = append(r.mu.seen, p)
+}
+
+func (r *recordingFS) paths() []string {
+	out := make([]string, len(r.mu.seen))
+	copy(out, r.mu.seen)
+	return out
+}
+
+func (r *recordingFS) Open(name string) (io.ReadCloser, error) {
+	r.record(name)
+	return r.inner.Open(name)
+}
+
+func (r *recordingFS) ReadFile(name string) ([]byte, error) {
+	r.record(name)
+	return r.inner.ReadFile(name)
+}
+
+func (r *recordingFS) Stat(name string) (fs.FileInfo, error) {
+	r.record(name)
+	return r.inner.Stat(name)
+}
+
+func (r *recordingFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	r.record(root)
+	return r.inner.WalkDir(root, fn)
+}

--- a/pkg/lsp/fs.go
+++ b/pkg/lsp/fs.go
@@ -1,0 +1,57 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
+)
+
+// FileSystem is the filesystem abstraction the LSP server uses for every
+// disk-touching operation: loading .coraza.json, walking the workspace
+// during global indexing, sniffing files for SecLang content, and verifying
+// the targets of Include directives.
+//
+// CLI users get OSFileSystem() by default and never need to think about this.
+// Embedders that host the LSP inside a larger application — for example a web
+// tool that serves rules from a database — pass a sandboxed implementation
+// (such as NewMemFS) so the LSP cannot read files outside the embedder's
+// intended scope.
+type FileSystem = vfs.FileSystem
+
+// OSFileSystem returns a FileSystem backed by the real OS filesystem. This is
+// the default; you only need to call this directly if you want to wrap or
+// compose it.
+func OSFileSystem() FileSystem { return vfs.OSFileSystem() }
+
+// NewMemFS returns an in-memory FileSystem populated from the given map of
+// path → contents. Useful for tests and for embedders serving rules from a
+// non-filesystem source. See vfs.NewMemFS for the path-resolution rules.
+func NewMemFS(files map[string][]byte) FileSystem { return vfs.NewMemFS(files) }
+
+// Option configures a Server. Pass options to New.
+type Option func(*serverOptions)
+
+type serverOptions struct {
+	fs FileSystem
+}
+
+func defaultOptions() *serverOptions {
+	return &serverOptions{fs: OSFileSystem()}
+}
+
+// WithFileSystem makes the server read all files through the given FileSystem.
+// When omitted, the server uses OSFileSystem().
+//
+// Embedders running the LSP in a multi-tenant web application should pass a
+// MemFS (or a custom FileSystem) so the LSP cannot escape the per-session
+// document set. Without this, didOpen / Include resolution / workspace
+// indexing all read directly from the host's disk.
+func WithFileSystem(fs FileSystem) Option {
+	return func(o *serverOptions) {
+		if fs != nil {
+			o.fs = fs
+		}
+	}
+}

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"encoding/json"
@@ -15,6 +15,7 @@ import (
 
 	"github.com/coraza-incubator/coraza-lsp/internal/config"
 
+	"github.com/gorilla/websocket"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	glspserver "github.com/tliron/glsp/server"
@@ -36,20 +37,36 @@ type Server struct {
 	store     *DocumentStore
 	validator *analysis.Validator
 	glsp      *glspserver.Server
+	fs        FileSystem
 
 	// ctxMu guards ctx; captured from any handler call for async notifications.
 	ctxMu sync.RWMutex
 	ctx   *glsp.Context
 
 	// cfgState holds the live `.coraza.json` and its derived analysis options.
-	// See internal/server/config.go.
+	// See pkg/lsp/config.go.
 	cfgState configState
 }
 
-// New creates and wires up a new Server ready to call RunStdio / RunTCP / RunWebSocket.
-func New(version string) *Server {
+// New creates and wires up a new Server ready to call RunStdio / RunTCP /
+// RunWebSocket / ServeWebSocket.
+//
+// Pass options to customise behaviour:
+//   - WithFileSystem to inject a sandboxed FileSystem (required for embedders
+//     that host the LSP in a multi-tenant web application — without it the
+//     LSP reads directly from the host's disk).
+//
+// With no options the server behaves identically to previous releases: it
+// uses OSFileSystem() and operates against the real disk.
+func New(version string, opts ...Option) *Server {
+	o := defaultOptions()
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	s := &Server{
 		store: NewDocumentStore(),
+		fs:    o.fs,
 	}
 
 	// Debounced Coraza oracle — fires 300 ms after the last change and pushes diagnostics.
@@ -90,8 +107,23 @@ func (s *Server) RunStdio() error { return s.glsp.RunStdio() }
 // RunTCP starts the LSP server on the given TCP address (e.g. "127.0.0.1:7998").
 func (s *Server) RunTCP(addr string) error { return s.glsp.RunTCP(addr) }
 
-// RunWebSocket starts the LSP server on the given WebSocket address.
+// RunWebSocket starts the LSP server on the given WebSocket address. It binds
+// its own listener and upgrades incoming HTTP requests. Embedders that already
+// own an HTTP router (and want to authenticate the upgrade themselves) should
+// upgrade in their own handler and call ServeWebSocket on the resulting
+// *websocket.Conn instead.
 func (s *Server) RunWebSocket(addr string) error { return s.glsp.RunWebSocket(addr) }
+
+// ServeWebSocket drives the LSP protocol over an already-upgraded WebSocket
+// connection. It blocks until the client disconnects. Use this from an
+// authenticated HTTP handler:
+//
+//	upgrader := websocket.Upgrader{...}
+//	conn, err := upgrader.Upgrade(w, r, nil)
+//	if err != nil { return }
+//	defer conn.Close()
+//	lspsrv.ServeWebSocket(conn)
+func (s *Server) ServeWebSocket(conn *websocket.Conn) { s.glsp.ServeWebSocket(conn) }
 
 // saveCtx stores the most-recent glsp.Context for async notifications.
 func (s *Server) saveCtx(ctx *glsp.Context) {
@@ -330,6 +362,7 @@ func (s *Server) definitionHandler(ctx *glsp.Context, params *protocol.Definitio
 		return nil, nil
 	}
 	locs := definition.Resolve(
+		s.fs,
 		doc.AST,
 		int(params.Position.Line),
 		int(params.Position.Character),

--- a/pkg/lsp/handler_test.go
+++ b/pkg/lsp/handler_test.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"encoding/json"

--- a/pkg/lsp/workspace.go
+++ b/pkg/lsp/workspace.go
@@ -2,15 +2,15 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
 )
 
 // indexedFile is a parsed rule file that the user did not open in the editor.
@@ -29,12 +29,12 @@ type indexedFile struct {
 //
 // The scan is synchronous. Callers that care about UI responsiveness should
 // invoke it from a goroutine (LoadConfig does when Global is true).
-func indexWorkspace(root string, filePatterns, ignore []string) map[string]*indexedFile {
+func indexWorkspace(filesys vfs.FileSystem, root string, filePatterns, ignore []string) map[string]*indexedFile {
 	out := map[string]*indexedFile{}
 	if root == "" {
 		return out
 	}
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	_ = filesys.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil {
 			return nil
 		}
@@ -50,10 +50,10 @@ func indexWorkspace(root string, filePatterns, ignore []string) map[string]*inde
 		if matchesAny(path, ignore, root) {
 			return nil
 		}
-		if !sniffsAsSecLang(path) {
+		if !sniffsAsSecLang(filesys, path) {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		data, err := filesys.ReadFile(path)
 		if err != nil {
 			return nil
 		}
@@ -105,8 +105,8 @@ func matchesAny(path string, globs []string, root string) bool {
 // sniffsAsSecLang reads the first ~4 KB of path and returns true iff it sees
 // a SecLang directive at the start of some non-comment line within the first
 // 20 lines. Keeps nginx/apache/etc. .conf files out of the index.
-func sniffsAsSecLang(path string) bool {
-	f, err := os.Open(path)
+func sniffsAsSecLang(filesys vfs.FileSystem, path string) bool {
+	f, err := filesys.Open(path)
 	if err != nil {
 		return false
 	}

--- a/pkg/lsp/workspace_test.go
+++ b/pkg/lsp/workspace_test.go
@@ -2,7 +2,7 @@
 // Author: Juan Pablo Tosso <pablo@owasp.org>
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package lsp
 
 import (
 	"os"
@@ -14,7 +14,11 @@ import (
 
 	"github.com/coraza-incubator/coraza-lsp/internal/config"
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
+	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
 )
+
+// testFS is the FileSystem used by indexWorkspace tests in this file.
+var testFS = vfs.OSFileSystem()
 
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
@@ -41,7 +45,7 @@ func TestIndexWorkspace_SniffsSecLang(t *testing.T) {
 	writeFile(t, filepath.Join(root, "rules", "notes.txt"),
 		`SecRule ARGS "@rx x" "id:2,phase:2,deny"`)
 
-	idx := indexWorkspace(root, []string{"**/*.conf"}, []string{"**/.git/**"})
+	idx := indexWorkspace(testFS, root, []string{"**/*.conf"}, []string{"**/.git/**"})
 	assert.Len(t, idx, 2, "expected two indexed SecLang files")
 
 	// Spot-check the parse worked.
@@ -60,7 +64,7 @@ func TestIndexWorkspace_RespectsIgnore(t *testing.T) {
 	writeFile(t, filepath.Join(root, ".git", "hidden.conf"),
 		`SecRule ARGS "@rx x" "id:3,phase:2,deny"`)
 
-	idx := indexWorkspace(root,
+	idx := indexWorkspace(testFS, root,
 		[]string{"**/*.conf"},
 		[]string{"**/deprecated/**", "**/.git/**"})
 
@@ -73,7 +77,7 @@ func TestIndexWorkspace_RespectsIgnore(t *testing.T) {
 
 func TestIndexWorkspace_EmptyRoot(t *testing.T) {
 	t.Parallel()
-	idx := indexWorkspace("", []string{"**/*.conf"}, nil)
+	idx := indexWorkspace(testFS, "", []string{"**/*.conf"}, nil)
 	assert.Empty(t, idx)
 }
 


### PR DESCRIPTION
## Summary

Promotes the language server's HTTP/WebSocket-driving code from `internal/server` to a public `pkg/lsp` package so Go applications can embed coraza-lsp in-process. Driving use case: a web tool serving SecLang rules from a database that wants real LSP features (completion, hover, definition, formatting, code actions, diagnostics from the live Coraza WAF oracle) in a browser editor without spawning and supervising a subprocess.

## Public API additions

- `lsp.New(version string, opts ...Option) *Server` — functional-options constructor.
- `(*Server).ServeWebSocket(*websocket.Conn)` — drives the protocol over an already-upgraded WebSocket so embedders can authenticate the upgrade in their own HTTP handler. The existing `RunWebSocket(addr)` keeps working unchanged.
- `lsp.FileSystem` interface + `lsp.WithFileSystem(fs)` option. Embedders pass a sandboxed implementation (e.g. `lsp.NewMemFS(map[string][]byte{...})`) so the LSP cannot read files outside the embedder's intended scope — important for multi-tenant deployments. CLI behaviour is unchanged: the default is `lsp.OSFileSystem()`.
- `config.LoadFS(fs, path)` and `config.DiscoverFS(fs, start)` accept an explicit FileSystem; `config.Load`/`config.Discover` keep working and now delegate to the OS-backed variants.

## Filesystem injection

Threaded a `vfs.FileSystem` parameter through every site that previously called `os.*` directly, so embedders get strict sandboxing by construction:

- `internal/config/config.go` — `LoadFS`, `DiscoverFS` (replace `os.ReadFile`, `os.Stat`)
- `pkg/lsp/workspace.go` — `indexWorkspace`, `sniffsAsSecLang` (replace `filepath.WalkDir`, `os.ReadFile`, `os.Open`)
- `internal/definition/definition.go` — `resolveIncludePath`, `fileExists` (replace `os.Stat`)

The interface lives in `internal/vfs` with a public type alias re-export from `pkg/lsp` to keep the import graph cycle-free.

## Other changes

- Bumped `github.com/corazawaf/coraza/v3` from v3.4.0 to v3.5.0. Full test suite re-run; no diagnostic-message diffs observed.
- `editors/monaco/README.md` gains an "Embedding the language server in a Go application" section with a worked example.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Backwards compatibility

Fully additive. Every existing entry point (`RunStdio`, `RunTCP`, `RunWebSocket`, `New(version)`, `config.Load`, `config.Discover`) keeps its previous signature and behaviour. CLI users (`coraza-lsp --stdio`, the VS Code extension, the Neovim plugin) are unaffected.

## Test plan

- [x] `make test` — 943 tests pass (was 932; +11 new)
- [x] New `internal/vfs/vfs_test.go` — OSFileSystem + MemFS contract (Open/ReadFile/Stat/WalkDir, SkipDir semantics, defensive copy)
- [x] New `pkg/lsp/embed_test.go` — embedding API (constructor + WithFileSystem + MemFS reject-out-of-scope-paths)
- [x] All pre-existing tests pass unchanged
- [x] Lint: zero new issues introduced (pre-existing errcheck warnings unchanged)
- [x] CLI binary builds and runs identically (`go build ./cmd/coraza-lsp && ./coraza-lsp --stdio` smoke)