### PR TITLE
fix(highlight): correct SecLang grammar bugs + tokenization test harness

### DIFF
--- a/.github/workflows/editors.yml
+++ b/.github/workflows/editors.yml
@@ -11,6 +11,7 @@ on:
     branches: ["**"]
     paths:
       - "editors/**"
+      - "test/highlight/**"
       - "cmd/**"
       - "internal/**"
       - "go.mod"
@@ -19,6 +20,7 @@ on:
   pull_request:
     paths:
       - "editors/**"
+      - "test/highlight/**"
       - "cmd/**"
       - "internal/**"
       - "go.mod"
@@ -55,6 +57,25 @@ jobs:
         with:
           name: binary-${{ matrix.os }}
           path: bin/${{ matrix.binary }}
+
+  # -------------------------------------------------------------------------
+  # TextMate grammar: snapshot + highlighting-hole tests (no binary needed).
+  # Tokenizes with the same vscode-textmate + Oniguruma engine VS Code ships.
+  # -------------------------------------------------------------------------
+  grammar-tests:
+    name: TextMate grammar tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install
+        working-directory: test/highlight
+      - name: Run grammar snapshot + hole tests
+        run: npm test
+        working-directory: test/highlight
 
   # -------------------------------------------------------------------------
   # VSCode extension: compile + tests (requires a built binary).

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ editors/vscode/*.vsix
 editors/monaco/node_modules/
 editors/monaco/dist/
 
+# Highlight grammar test harness
+test/highlight/node_modules/
+
 # Local Claude Code scratch/session state
 .claude/

--- a/editors/vim/syntax/seclang.vim
+++ b/editors/vim/syntax/seclang.vim
@@ -67,4 +67,11 @@ highlight default link seclangOperator     Function
 highlight default link seclangActionKey    Type
 highlight default link seclangTransformation Constant
 
+" ── Multi-line sync ─────────────────────────────────────────────────────────
+" Action-list and operator strings span several physical lines via '\'
+" continuation. Sync from far enough back that scrolling into the middle of a
+" long multi-line rule (e.g. CRS 942220 spans ~20 lines) still resolves the
+" enclosing quoted-string region correctly.
+syntax sync minlines=50
+
 let b:current_syntax = 'seclang'

--- a/editors/vim/test/spec/syntax_spec.lua
+++ b/editors/vim/test/spec/syntax_spec.lua
@@ -1,0 +1,100 @@
+-- syntax_spec.lua: Tests for SecLang syntax highlighting (syntax/seclang.vim).
+--
+-- These lock in the vim-side analogue of the TextMate grammar fixes: the vim
+-- region model handles escaped quotes (skip=/\\"/) and column-0 continuations,
+-- so a multi-line rule whose msg value embeds \" must NOT break highlighting of
+-- the rest of the rule (the bug that broke the TextMate grammar). They also
+-- assert the core token classes (directive, variable, operator, transformation).
+
+local function open_conf(content)
+  local path = os.tmpname() .. '.conf'
+  local f = assert(io.open(path, 'w'))
+  f:write(content)
+  f:close()
+  vim.cmd('edit ' .. vim.fn.fnameescape(path))
+  -- Force the filetype so syntax/seclang.vim is sourced. We force (not rely on
+  -- ftdetect) because this is a SYNTAX test, not a detection test — ftdetect is
+  -- covered by filetype_spec. `syntax sync fromstart` makes synID() resolve the
+  -- multi-line action-string region from the top of the buffer rather than from
+  -- a limited sync window, so positions inside a continuation line report the
+  -- region's group correctly.
+  vim.cmd('set filetype=seclang')
+  vim.cmd('syntax sync fromstart')
+  assert.equals('seclang', vim.bo.filetype)
+  return path
+end
+
+-- syn_name returns the syntax group name at 1-indexed (lnum, col).
+local function syn_name(lnum, col)
+  return vim.fn.synIDattr(vim.fn.synID(lnum, col, 1), 'name')
+end
+
+-- first_col finds the 1-indexed column where `needle` starts on line `lnum`.
+local function first_col(lnum, needle)
+  local line = vim.fn.getline(lnum)
+  local s = line:find(needle, 1, true)
+  return s
+end
+
+local function close_all_bufs()
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end
+end
+
+describe('syntax/seclang', function()
+  after_each(close_all_bufs)
+
+  it('classifies directive, variable and operator on a SecRule line', function()
+    local p = open_conf('SecRule ARGS "@rx attack" "id:1,phase:2,deny"\n')
+    assert.equals('seclangDirective', syn_name(1, first_col(1, 'SecRule')))
+    assert.equals('seclangVariable', syn_name(1, first_col(1, 'ARGS')))
+    assert.equals('seclangOperator', syn_name(1, first_col(1, '@rx')))
+    os.remove(p)
+  end)
+
+  it('colors t: transformations distinctly', function()
+    local p = open_conf('SecRule ARGS "@rx x" "id:1,phase:2,t:lowercase,deny"\n')
+    -- the transformation name (after t:) is its own group, not a bare string
+    local col = first_col(1, 'lowercase')
+    assert.equals('seclangTransformation', syn_name(1, col))
+    os.remove(p)
+  end)
+
+  it('does not break on an escaped double quote inside a single-quoted msg', function()
+    -- Regression: \" inside a msg:'...' value must not terminate the action
+    -- string region. Everything after it must stay highlighted (seclangString),
+    -- never fall through to an empty/None group.
+    local content = table.concat({
+      'SecRule ARGS "@rx foo" \\',
+      '    "id:1,phase:2,\\',
+      "    msg:'is the \\\"magic number\\\" crash',\\",
+      '    severity:2,\\',
+      "    setvar:'tx.score=+1'\"",
+    }, '\n') .. '\n'
+    local p = open_conf(content)
+    -- The continuation lines (3,4,5) are inside the action string region.
+    for _, lnum in ipairs({ 3, 4, 5 }) do
+      local line = vim.fn.getline(lnum)
+      for c = (line:find('%S')), #line do
+        local name = syn_name(lnum, c)
+        assert.is_true(
+          name ~= '',
+          string.format('L%d col %d (%q) fell through to no syntax group', lnum, c, line:sub(c, c))
+        )
+      end
+    end
+    os.remove(p)
+  end)
+
+  it('handles a column-0 (unindented) continuation line', function()
+    -- ModSecurity-style rules often put the continuation quote at column 0.
+    local content = 'SecRule REQBODY_ERROR "!@eq 0" \\\n"id:200002,phase:2,deny,severity:2"\n'
+    local p = open_conf(content)
+    -- The action string on line 2 must be highlighted, not plain text.
+    assert.equals('seclangString', syn_name(2, 1))
+    os.remove(p)
+  end)
+end)

--- a/editors/vscode/syntaxes/seclang.tmLanguage.json
+++ b/editors/vscode/syntaxes/seclang.tmLanguage.json
@@ -42,9 +42,9 @@
       }
     },
     "operator-continuation": {
-      "comment": "Operator expression on a continuation line, e.g. '    \"@rx pattern\" \\'. Must be listed before action-list-continuation so it wins over the generic indented-quote rule.",
+      "comment": "Operator expression on a continuation line, e.g. '    \"@rx pattern\" \\'. Must be listed before action-list-continuation so it wins over the generic indented-quote rule. Leading whitespace is optional (\\s*) because ModSecurity-style rules frequently put the continuation quote at column 0.",
       "name": "meta.operator.seclang",
-      "match": "^\\s+\"(!?)(@)([a-zA-Z][a-zA-Z0-9_]*)((?:\\s+(?:[^\"\\\\]|\\\\.)*)?)\"",
+      "match": "^\\s*\"(!?)(@)([a-zA-Z][a-zA-Z0-9_]*)((?:\\s+(?:[^\"\\\\]|\\\\.)*)?)\"",
       "captures": {
         "1": { "name": "keyword.operator.seclang" },
         "2": { "name": "entity.name.function.seclang" },
@@ -53,10 +53,10 @@
       }
     },
     "action-list-continuation": {
-      "comment": "Action list that starts on a continuation line (indented double-quoted string). The negative lookahead (?![!]?@) prevents this rule from consuming operator continuation lines like '\"@rx ...\"'.",
+      "comment": "Action list that starts on a continuation line (indented double-quoted string). The negative lookahead (?![!]?@) prevents this rule from consuming operator continuation lines like '\"@rx ...\"'. The end uses a negative lookbehind so an escaped quote (\\\") inside the action string does not prematurely close the list.",
       "name": "meta.action-list.seclang",
-      "begin": "^(\\s+)(\"(?![!]?@))",
-      "end": "\"",
+      "begin": "^(\\s*)(\"(?![!]?@))",
+      "end": "(?<!\\\\)\"",
       "patterns": [
         { "include": "#action-msg-quoted" },
         { "include": "#action-tag-quoted" },
@@ -72,17 +72,46 @@
         { "include": "#action-severity" },
         { "include": "#action-skipafter" },
         { "include": "#action-ctl" },
+        { "include": "#transformation" },
         { "include": "#macro-expansion" },
         { "include": "#action-separator" },
         { "include": "#action-key" },
         { "include": "#action-value" },
-        { "include": "#transformation" },
         { "include": "#continuation" }
       ]
     },
     "variable-list": {
-      "name": "entity.name.class.seclang",
-      "match": "[A-Za-z_][A-Za-z0-9_.]*(?::[^\\s\"\\\\]*)?"
+      "comment": "A SecRule target: one or more variables joined by '|', each optionally prefixed by '&' (count) or '!' (exclusion) and optionally followed by ':selector'. Sub-rules give the separator, modifier, collection name and selector distinct scopes.",
+      "patterns": [
+        { "include": "#variable-modifier" },
+        { "include": "#variable-separator" },
+        { "include": "#variable-keyed" },
+        { "include": "#variable-name" }
+      ]
+    },
+    "variable-modifier": {
+      "comment": "Count quantifier & and negation/exclusion ! prefixing a variable (e.g. &ARGS, !ARGS:z). Lookahead ensures a variable name follows so a stray & / ! is not miscoloured.",
+      "match": "[&!](?=[A-Za-z_])",
+      "name": "keyword.operator.variable.seclang"
+    },
+    "variable-separator": {
+      "comment": "Pipe separating variables in a target list (ARGS|REQUEST_HEADERS|...).",
+      "match": "\\|",
+      "name": "punctuation.separator.variable.seclang"
+    },
+    "variable-keyed": {
+      "comment": "COLLECTION:selector. Selector forms, in priority order: /regex/ (may contain | and escaped chars but NOT whitespace or quotes — a SecRule target never spans spaces, which also stops a non-regex selector like XML:/* from greedily matching a far-away '/' in the operator string), 'single-quoted', or a plain key up to the next separator/space/quote. Collection name and selector get distinct scopes.",
+      "match": "([A-Za-z_][A-Za-z0-9_.]*)(:)(/(?:[^/\\s\"\\\\]|\\\\.)*/|'[^']*'|[^\\s\"\\\\|,]*)",
+      "captures": {
+        "1": { "name": "entity.name.class.seclang" },
+        "2": { "name": "punctuation.separator.key.seclang" },
+        "3": { "name": "variable.parameter.selector.seclang" }
+      }
+    },
+    "variable-name": {
+      "comment": "Bare collection/variable name with no selector (ARGS, REQUEST_HEADERS, TX, &MATCHED_VARS).",
+      "match": "[A-Za-z_][A-Za-z0-9_.]*",
+      "name": "entity.name.class.seclang"
     },
     "operator-expr": {
       "name": "meta.operator.seclang",
@@ -97,7 +126,7 @@
     "action-string": {
       "name": "meta.action-list.seclang",
       "begin": "\"",
-      "end": "\"",
+      "end": "(?<!\\\\)\"",
       "patterns": [
         { "include": "#action-msg-quoted" },
         { "include": "#action-tag-quoted" },
@@ -113,11 +142,11 @@
         { "include": "#action-severity" },
         { "include": "#action-skipafter" },
         { "include": "#action-ctl" },
+        { "include": "#transformation" },
         { "include": "#macro-expansion" },
         { "include": "#action-separator" },
         { "include": "#action-key" },
-        { "include": "#action-value" },
-        { "include": "#transformation" }
+        { "include": "#action-value" }
       ]
     },
 
@@ -136,11 +165,14 @@
       }
     },
     "action-id": {
-      "comment": "id:N — rule identifier; N colored as a numeric constant.",
-      "match": "(id:)(['\"]?\\d+['\"]?)",
+      "comment": "id:N or id:'N'. Quotes matched as a balanced pair (see action-severity) so a trailing optional quote cannot swallow the action list's closing \" when id is the last, unquoted action.",
+      "match": "(id:)(?:(['\"])(\\d+)(['\"])|(\\d+))",
       "captures": {
         "1": { "name": "entity.other.attribute-name.seclang" },
-        "2": { "name": "constant.numeric.seclang" }
+        "2": { "name": "punctuation.definition.string.seclang" },
+        "3": { "name": "constant.numeric.seclang" },
+        "4": { "name": "punctuation.definition.string.seclang" },
+        "5": { "name": "constant.numeric.seclang" }
       }
     },
     "action-phase": {
@@ -168,13 +200,14 @@
       }
     },
     "action-severity": {
-      "comment": "severity:LEVEL or severity:'LEVEL' — severity colored as a language constant.",
-      "match": "(severity:)(['\"]?)(EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG|[0-7])(['\"]?)",
+      "comment": "severity:LEVEL or severity:'LEVEL'. The quotes are matched as a balanced pair via alternation (quoted form | unquoted form) rather than two independent optional quotes — an optional TRAILING quote would otherwise swallow the action list's own closing \" when severity is the last, unquoted action (e.g. ...,severity:2\").",
+      "match": "(severity:)(?:(['\"])(EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG|[0-7])(['\"])|(EMERGENCY|ALERT|CRITICAL|ERROR|WARNING|NOTICE|INFO|DEBUG|[0-7]))",
       "captures": {
         "1": { "name": "entity.other.attribute-name.seclang" },
         "2": { "name": "punctuation.definition.string.seclang" },
         "3": { "name": "constant.language.severity.seclang" },
-        "4": { "name": "punctuation.definition.string.seclang" }
+        "4": { "name": "punctuation.definition.string.seclang" },
+        "5": { "name": "constant.language.severity.seclang" }
       }
     },
     "action-skipafter": {
@@ -273,8 +306,9 @@
       "match": ","
     },
     "action-key": {
+      "comment": "Generic action key (word before ':' or ','). The lookbehind matches whitespace/comma/quote WITHOUT consuming it, so on indented continuation lines this rule starts at the word — tying with the specific action rules (action-msg-quoted, action-id, …) which are listed first and therefore win. Consuming leading whitespace here (the old \\s* form) made this rule start earlier than the specific rules, so it always won and, for msg:'… \\\"…\\\" …', exposed the escaped quotes and broke the action list.",
       "name": "entity.other.attribute-name.seclang",
-      "match": "(?:^|(?<=[,\"]))\\s*([a-zA-Z][a-zA-Z0-9_]*)(?=[:,\"]|$)"
+      "match": "(?:^|(?<=[\\s,\"]))([a-zA-Z][a-zA-Z0-9_]*)(?=[:,\"]|$)"
     },
     "action-value": {
       "name": "string.unquoted.action-value.seclang",
@@ -292,8 +326,12 @@
       }
     },
     "transformation": {
-      "name": "support.function.builtin.seclang",
-      "match": "(?<=t:)[a-zA-Z][a-zA-Z0-9_]*"
+      "comment": "t:NAME transformation. Matches 't:' + name as a unit, anchored to an action boundary (start / whitespace / comma / quote) so a substring like 'at:' cannot trigger it. Included BEFORE #action-value so the transformation name is not swallowed as a generic action value (the old (?<=t:) form lost the precedence race against action-value and was never applied).",
+      "match": "(?:^|(?<=[\\s,\"]))(t:)([a-zA-Z][a-zA-Z0-9_]*)",
+      "captures": {
+        "1": { "name": "entity.other.attribute-name.seclang" },
+        "2": { "name": "support.function.builtin.seclang" }
+      }
     },
     "continuation": {
       "name": "punctuation.separator.continuation.seclang",

--- a/test/highlight/README.md
+++ b/test/highlight/README.md
@@ -1,0 +1,57 @@
+# SecLang highlighting tests
+
+Tests for the SecLang **TextMate grammar** (`editors/vscode/syntaxes/seclang.tmLanguage.json`)
+that the VS Code and Monaco editors use for syntax highlighting. They tokenize
+with the exact engine VS Code ships — [`vscode-textmate`](https://github.com/microsoft/vscode-textmate)
+driving an Oniguruma WASM regex backend — so what they measure is the real
+in-editor highlighting, not an approximation.
+
+The vim syntax (`editors/vim/syntax/seclang.vim`) is covered separately by a
+Neovim plenary spec at `editors/vim/test/spec/syntax_spec.lua`.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `lib/grammar.mjs` | Loads the shipped grammar and tokenizes text (line → tokens+scopes). |
+| `tokenize.mjs` | CLI: dump every token of a file with its scope stack. |
+| `audit.mjs` | Sweep a corpus and report **highlighting holes** — non-whitespace tokens that got no scope beyond the root `source.seclang` (they'd render as plain, unstyled text). |
+| `fixtures/edge-cases.conf` | Hand-written corpus stressing operators, variable lists, macros, ctl/setvar, quoting, continuations and transformations. |
+| `snap/*.conf` + `*.snap` | `vscode-tmgrammar-snap` snapshots: the full scope stack of every token. A snapshot diff catches **wrong** scopes (e.g. a transformation mis-scoped as a plain value), which the hole sweep alone cannot. |
+
+## Running
+
+```bash
+cd test/highlight
+npm install
+npm test                 # snapshot tests + hole gate over fixtures (CI gate)
+
+# Ad-hoc:
+node tokenize.mjs ../../editors/vscode/testdata/simple.conf
+node audit.mjs --corpus /tmp/coreruleset/rules        # sweep real OWASP CRS
+npm run test:snap:update                              # re-bless snapshots after an intentional grammar change
+```
+
+`audit.mjs` accepts `--corpus DIR|FILE`, `--show N` (top-N holes), and
+`--max N` (exit non-zero if distinct holes exceed N).
+
+## What this caught
+
+Running the sweep over the full OWASP CRS, the ModSecurity example rules and
+the Coraza engine test corpus, plus the edge-case fixtures, surfaced and locked
+fixes for:
+
+1. An escaped quote (`\"`) inside a single-quoted `msg:'…'` value prematurely
+   terminated the action-list region, breaking highlighting for the rest of a
+   multi-line rule (region end now uses a negative lookbehind).
+2. The generic action-key rule consumed leading whitespace, so on indented
+   continuation lines it out-raced the specific `msg`/`id`/`severity`/… rules.
+3. Column-0 (unindented) continuation lines — the canonical `modsecurity.conf`
+   style — were not highlighted at all.
+4. A trailing optional quote in `severity:`/`id:` swallowed the action list's
+   own closing `"` when the action was last and unquoted (e.g. `…,severity:2"`).
+5. `t:` transformations were never scoped as transformations — the rule was
+   ordered after the generic value rule and never won.
+6. Variable targets now scope the `|` separator, the `&`/`!` modifiers and
+   `:selector` (plain / `'quoted'` / `/regex/`) distinctly, without a `/`-prefixed
+   non-regex selector (e.g. `XML:/*`) bleeding into the operator string.

--- a/test/highlight/audit.mjs
+++ b/test/highlight/audit.mjs
@@ -1,0 +1,105 @@
+// Copyright 2026 OWASP Coraza
+// SPDX-License-Identifier: Apache-2.0
+//
+// Audits SecLang highlighting over a corpus of rule files. Tokenizes each file
+// with the shipped grammar and reports "highlighting holes": non-whitespace
+// tokens that received no scope beyond the root `source.seclang` (so they would
+// render as plain unstyled text in an editor).
+//
+// Usage:
+//   node audit.mjs                       # audit ./fixtures
+//   node audit.mjs --corpus /tmp/coreruleset/rules
+//   node audit.mjs --corpus DIR --max 50 # fail if > 50 distinct holes
+//   node audit.mjs --corpus DIR --show 40
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { tokenizeText } from "./lib/grammar.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function arg(name, def) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+const corpus = resolve(arg("--corpus", join(__dirname, "fixtures")));
+const maxHoles = parseInt(arg("--max", "0"), 10);
+const show = parseInt(arg("--show", "30"), 10);
+
+// CRS `.data` files are plain pattern lists consumed by @pmFromFile/@ipMatchFromFile,
+// not SecLang source — they are deliberately excluded.
+const SECLANG_EXT = new Set([".conf", ".seclang"]);
+
+async function walk(dir, acc = []) {
+  for (const name of await readdir(dir)) {
+    const p = join(dir, name);
+    const s = await stat(p);
+    if (s.isDirectory()) await walk(p, acc);
+    else if (SECLANG_EXT.has(extname(name))) acc.push(p);
+  }
+  return acc;
+}
+
+// A token is a "hole" if its trimmed text is non-empty and its only scope is
+// the root. Pure punctuation that the grammar intentionally leaves unscoped
+// (quotes handled by the parent) is filtered out to reduce noise.
+const IGNORE = new Set(['"', "'", "\\"]);
+function isHole(t) {
+  const txt = t.text.trim();
+  if (txt === "" || IGNORE.has(txt)) return false;
+  return t.scopes.length <= 1;
+}
+
+const files = (await stat(corpus)).isDirectory()
+  ? await walk(corpus)
+  : [corpus];
+
+const holeBuckets = new Map(); // normalized text -> {count, examples:[]}
+let totalTokens = 0,
+  totalHoles = 0,
+  totalLines = 0;
+
+for (const f of files) {
+  let text;
+  try {
+    text = await readFile(f, "utf8");
+  } catch {
+    continue;
+  }
+  const lines = await tokenizeText(text);
+  totalLines += lines.length;
+  lines.forEach((toks, i) => {
+    for (const t of toks) {
+      if (t.text.trim() !== "") totalTokens++;
+      if (isHole(t)) {
+        totalHoles++;
+        const key = t.text.trim();
+        if (!holeBuckets.has(key)) holeBuckets.set(key, { count: 0, examples: [] });
+        const b = holeBuckets.get(key);
+        b.count++;
+        if (b.examples.length < 3)
+          b.examples.push(`${f.replace(corpus, ".")}:${i + 1}:${t.startIndex}`);
+      }
+    }
+  });
+}
+
+const sorted = [...holeBuckets.entries()].sort((a, b) => b[1].count - a[1].count);
+
+console.log(`corpus:        ${corpus}`);
+console.log(`files:         ${files.length}`);
+console.log(`lines:         ${totalLines}`);
+console.log(`tokens:        ${totalTokens}`);
+console.log(`holes (total): ${totalHoles}`);
+console.log(`holes (distinct text): ${sorted.length}`);
+console.log("");
+console.log(`Top ${Math.min(show, sorted.length)} highlighting holes (text → count, examples):`);
+for (const [text, b] of sorted.slice(0, show)) {
+  console.log(`  ${String(b.count).padStart(5)}  ${JSON.stringify(text).padEnd(36)} ${b.examples.join("  ")}`);
+}
+
+if (maxHoles > 0 && sorted.length > maxHoles) {
+  console.error(`\nFAIL: ${sorted.length} distinct holes > --max ${maxHoles}`);
+  process.exit(1);
+}

--- a/test/highlight/fixtures/edge-cases.conf
+++ b/test/highlight/fixtures/edge-cases.conf
@@ -1,0 +1,94 @@
+# SecLang highlighting edge-case corpus.
+# Synthetic but valid-shaped rules that stress the TextMate grammar:
+# operators, negation, variable selectors, macros, ctl/setvar, quoting,
+# continuations (indented and column-0), transformations, and directives.
+
+# ── Operators: presence, arguments, negation, no-arg ────────────────────────
+SecRule ARGS "@rx attack" "id:1,phase:2,deny"
+SecRule ARGS "@detectSQLi" "id:2,phase:2,deny"
+SecRule ARGS "!@rx ^$" "id:3,phase:2,pass"
+SecRule REQBODY_ERROR "!@eq 0" "id:4,phase:2,deny,severity:2"
+SecRule ARGS "@pmFromFile lfi-os-files.data" "id:5,phase:1,pass"
+SecRule ARGS "@within %{tx.allowed_methods}" "id:6,phase:1,pass"
+SecRule ARGS "@rx a#b#c" "id:7,phase:2,pass"
+SecRule ARGS "@rx attack\"vector" "id:8,phase:2,pass"
+SecRule ARGS "@rx it's a (?i:test)" "id:9,phase:2,pass"
+SecRule ARGS "@rx \d{1,5}" "id:10,phase:2,pass"
+
+# ── Variables: selectors, counts, negation, regex selectors, lists, XML ─────
+SecRule ARGS:user "@rx x" "id:20,phase:2,pass"
+SecRule ARGS:'user name' "@rx x" "id:21,phase:2,pass"
+SecRule &ARGS "@eq 0" "id:22,phase:2,pass"
+SecRule !ARGS:password "@rx x" "id:23,phase:2,pass"
+SecRule REQUEST_HEADERS:/^X-Forwarded/ "@rx x" "id:24,phase:1,pass"
+SecRule ARGS|ARGS_NAMES|!ARGS:secret "@rx x" "id:25,phase:2,pass"
+SecRule XML:/* "@rx x" "id:26,phase:2,pass"
+SecRule XML://@attr "@rx x" "id:27,phase:2,pass"
+SecRule TX:anomaly_score "@gt 5" "id:28,phase:5,pass"
+
+# ── Transformations (chained) ───────────────────────────────────────────────
+SecRule ARGS "@rx x" "id:30,phase:2,t:none,t:lowercase,t:urlDecodeUni,t:removeNulls,t:compressWhitespace,pass"
+
+# ── Macros in msg / logdata / setvar; key forms .key and :key ───────────────
+SecRule ARGS "@rx x" \
+    "id:31,phase:2,pass,\
+    msg:'Matched %{TX.0} in %{MATCHED_VAR_NAME}',\
+    logdata:'val=%{MATCHED_VAR} score=%{tx.anomaly_score}',\
+    setvar:'tx.score=+%{tx.critical_anomaly_score}'"
+SecRule GEO:COUNTRY_CODE "@streq CN" "id:32,phase:1,deny,setvar:tx.block=1"
+
+# ── setvar / setenv / expirevar / initcol variants (quoted + unquoted) ──────
+SecAction "id:40,phase:1,pass,nolog,setvar:tx.paranoia_level=1"
+SecAction "id:41,phase:1,pass,nolog,setvar:!tx.foo"
+SecAction "id:42,phase:1,pass,nolog,expirevar:tx.foo=60"
+SecAction "id:43,phase:1,pass,nolog,initcol:ip=%{REMOTE_ADDR}"
+SecAction "id:44,phase:1,pass,nolog,setenv:'TESTING=1'"
+
+# ── ctl variants ────────────────────────────────────────────────────────────
+SecRule ARGS "@rx x" "id:50,phase:1,pass,ctl:ruleEngine=Off"
+SecRule ARGS "@rx x" "id:51,phase:1,pass,ctl:auditLogParts=+E"
+SecRule ARGS "@rx x" "id:52,phase:1,pass,ctl:ruleRemoveTargetById=981176;ARGS:foo"
+
+# ── id / severity / phase: quoted, unquoted, word, last-action ──────────────
+SecRule ARGS "@rx x" "phase:request,pass,id:60"
+SecRule ARGS "@rx x" "id:'61',phase:logging,pass,severity:'CRITICAL'"
+SecRule ARGS "@rx x" "id:62,phase:2,pass,severity:WARNING"
+SecRule ARGS "@rx x" "id:63,phase:2,pass,severity:2"
+SecRule ARGS "@rx x" "phase:2,pass,severity:2,id:64"
+
+# ── Chained rules (child has no id) ─────────────────────────────────────────
+SecRule ARGS "@rx x" "id:70,phase:2,chain,deny"
+    SecRule REQUEST_METHOD "@streq POST" "t:none"
+
+# ── Column-0 continuation (ModSecurity style) ───────────────────────────────
+SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
+"id:80,phase:2,t:none,log,deny,status:400, \
+msg:'Multipart failed: PE %{REQBODY_PROCESSOR_ERROR}, BQ %{MULTIPART_BOUNDARY_QUOTED}',\
+severity:2"
+
+# ── Operator split onto its own continuation line ───────────────────────────
+SecRule ARGS \
+    "@rx (?i:union[\s]+select)" \
+    "id:81,phase:2,deny,msg:'SQLi'"
+
+# ── Directives that take rule-id ranges / tags ──────────────────────────────
+SecRuleRemoveById 942100
+SecRuleRemoveById 942100-942999
+SecRuleRemoveByTag "attack-sqli"
+SecRuleUpdateTargetById 942100 "!ARGS:foo"
+SecRuleUpdateActionById 942100 "t:none,deny"
+
+# ── Markers (bare + quoted) ─────────────────────────────────────────────────
+SecMarker END-REQUEST-942-APPLICATION-ATTACK-SQLI
+SecMarker "BEGIN SECTION"
+SecRule ARGS "@rx x" "id:90,phase:2,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+
+# ── Includes / config directives ────────────────────────────────────────────
+Include /etc/crs/rules/*.conf
+Include rules/local.conf
+SecRuleEngine DetectionOnly
+SecDefaultAction "phase:2,log,auditlog,pass"
+SecComponentSignature "OWASP_CRS/4.0.0"
+
+# ── msg containing escaped single quote and escaped double quote ────────────
+SecRule ARGS "@rx x" "id:100,phase:2,pass,msg:'it\'s the \"magic\" value'"

--- a/test/highlight/lib/grammar.mjs
+++ b/test/highlight/lib/grammar.mjs
@@ -1,0 +1,81 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Loads the shipped SecLang TextMate grammar and tokenizes text with the exact
+// engine VS Code uses (vscode-textmate driving an Oniguruma WASM regex backend).
+// Returns, for every line, the list of {startIndex, endIndex, text, scopes}.
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import onigModule from "vscode-oniguruma";
+import vsctmModule from "vscode-textmate";
+
+// Both deps ship as CommonJS; under ESM their APIs hang off the default export.
+const oniguruma = onigModule.default ?? onigModule;
+const vsctm = vsctmModule.default ?? vsctmModule;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// Path to the grammar shipped in the VS Code extension — single source of truth.
+export const GRAMMAR_PATH = resolve(
+  __dirname,
+  "../../../editors/vscode/syntaxes/seclang.tmLanguage.json",
+);
+export const SCOPE_NAME = "source.seclang";
+
+let _registryPromise = null;
+
+async function makeRegistry() {
+  const wasmPath = require.resolve("vscode-oniguruma/release/onig.wasm");
+  const wasmBin = await readFile(wasmPath);
+  await oniguruma.loadWASM(wasmBin.buffer);
+
+  const onigLib = Promise.resolve({
+    createOnigScanner: (patterns) => new oniguruma.OnigScanner(patterns),
+    createOnigString: (s) => new oniguruma.OnigString(s),
+  });
+
+  const grammarRaw = await readFile(GRAMMAR_PATH, "utf8");
+  const grammarJson = vsctm.parseRawGrammar(grammarRaw, GRAMMAR_PATH);
+
+  return new vsctm.Registry({
+    onigLib,
+    loadGrammar: async (scopeName) =>
+      scopeName === SCOPE_NAME ? grammarJson : null,
+  });
+}
+
+export async function loadGrammar() {
+  if (!_registryPromise) _registryPromise = makeRegistry();
+  const registry = await _registryPromise;
+  const grammar = await registry.loadGrammar(SCOPE_NAME);
+  if (!grammar) throw new Error(`grammar ${SCOPE_NAME} failed to load`);
+  return grammar;
+}
+
+// tokenizeText returns an array of lines; each line is an array of token
+// objects {startIndex, endIndex, text, scopes}. Carries grammar state across
+// lines so begin/end (continuation) rules behave exactly as in the editor.
+export async function tokenizeText(text) {
+  const grammar = await loadGrammar();
+  const lines = text.split("\n");
+  let ruleStack = vsctm.INITIAL;
+  const out = [];
+  for (const line of lines) {
+    const r = grammar.tokenizeLine(line, ruleStack);
+    out.push(
+      r.tokens.map((t) => ({
+        startIndex: t.startIndex,
+        endIndex: t.endIndex,
+        text: line.slice(t.startIndex, t.endIndex),
+        scopes: t.scopes,
+      })),
+    );
+    ruleStack = r.ruleStack;
+  }
+  return out;
+}

--- a/test/highlight/package-lock.json
+++ b/test/highlight/package-lock.json
@@ -1,0 +1,283 @@
+{
+  "name": "coraza-lsp-highlight-test",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coraza-lsp-highlight-test",
+      "version": "0.0.0",
+      "dependencies": {
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.2.0"
+      },
+      "devDependencies": {
+        "vscode-tmgrammar-test": "^0.1.3"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+      "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+      "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
+      "integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bottleneck": "^2.19.5",
+        "chalk": "^2.4.2",
+        "commander": "^9.2.0",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^7.0.1"
+      },
+      "bin": {
+        "vscode-tmgrammar-snap": "dist/snapshot.js",
+        "vscode-tmgrammar-test": "dist/unit.js"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/vscode-textmate": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/test/highlight/package.json
+++ b/test/highlight/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "coraza-lsp-highlight-test",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "TextMate grammar tokenization harness for the SecLang grammar. Uses the same vscode-textmate + Oniguruma engine VS Code ships, so it measures real highlighting.",
+  "scripts": {
+    "tokenize": "node tokenize.mjs",
+    "audit": "node audit.mjs",
+    "test:snap": "vscode-tmgrammar-snap -g ../../editors/vscode/syntaxes/seclang.tmLanguage.json -s source.seclang \"snap/*.conf\"",
+    "test:snap:update": "vscode-tmgrammar-snap -u -g ../../editors/vscode/syntaxes/seclang.tmLanguage.json -s source.seclang \"snap/*.conf\"",
+    "test:holes": "node audit.mjs --corpus fixtures --max 0",
+    "test": "npm run test:snap && npm run test:holes"
+  },
+  "dependencies": {
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.2.0"
+  },
+  "devDependencies": {
+    "vscode-tmgrammar-test": "^0.1.3"
+  }
+}

--- a/test/highlight/snap/crs-942220-multiline.conf
+++ b/test/highlight/snap/crs-942220-multiline.conf
@@ -1,0 +1,20 @@
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)^(?:429496729[56]|2(?:14748364[78]|.22507385850720(?:07|11)e-308)|-(?:214748364[89]|0000023456)|00000(?:12345|23456)|1e309)$" \
+    "id:942220,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,\
+    msg:'Looking for integer overflow attacks, these are taken from skipfish, except 2.2.2250738585072011e-308 is the \"magic number\" crash',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-sqli',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/ATTACK-SQLI',\
+    tag:'capec/1000/152/248/66',\
+    ver:'OWASP_CRS/4.27.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/test/highlight/snap/crs-942220-multiline.conf.snap
+++ b/test/highlight/snap/crs-942220-multiline.conf.snap
@@ -1,0 +1,189 @@
+>SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)^(?:429496729[56]|2(?:14748364[78]|.22507385850720(?:07|11)e-308)|-(?:214748364[89]|0000023456)|00000(?:12345|23456)|1e309)$" \
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                       ^ source.seclang meta.rule.seclang punctuation.separator.variable.seclang
+#                        ^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                                             ^ source.seclang meta.rule.seclang punctuation.separator.variable.seclang
+#                                              ^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                                                        ^ source.seclang meta.rule.seclang punctuation.separator.variable.seclang
+#                                                         ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                                                             ^ source.seclang meta.rule.seclang punctuation.separator.variable.seclang
+#                                                              ^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                                                                 ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#                                                                  ^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                                                                    ^ source.seclang meta.rule.seclang
+#                                                                     ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                                                      ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                                                       ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                                                                                                                                                                                          ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                                                                                                                                                                                           ^ source.seclang meta.rule.seclang
+#                                                                                                                                                                                                            ^ source.seclang meta.rule.seclang punctuation.separator.continuation.seclang
+>    "id:942220,\
+#^^^^^ source.seclang meta.action-list.seclang
+#     ^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^^^^^^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#              ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#               ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    phase:2,\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#          ^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#           ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#            ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    block,\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^ source.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#         ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#          ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    capture,\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^ source.seclang meta.action-list.seclang keyword.control.flow.seclang
+#           ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#            ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    t:none,t:urlDecodeUni,\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#      ^^^^ source.seclang meta.action-list.seclang support.function.builtin.seclang
+#          ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#           ^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#             ^^^^^^^^^^^^ source.seclang meta.action-list.seclang support.function.builtin.seclang
+#                         ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                          ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    msg:'Looking for integer overflow attacks, these are taken from skipfish, except 2.2.2250738585072011e-308 is the \"magic number\" crash',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                                                                                                                                            ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                                                                                                             ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                                                                                              ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#            ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#             ^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang
+#                           ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                             ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                               ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.key.seclang
+#                                 ^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                  ^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang
+#                                                ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                                  ^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                                                  ^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                                   ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang
+#                                                                     ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                                                       ^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                                                                  ^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                                                   ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                                                    ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                                     ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'application-multi',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                          ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                           ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'language-multi',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                       ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                        ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'platform-multi',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                       ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                        ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'attack-sqli',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                    ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                     ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                      ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'paranoia-level/1',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                         ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                          ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                           ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'OWASP_CRS',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                  ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                   ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                    ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'OWASP_CRS/ATTACK-SQLI',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                              ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                               ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    tag:'capec/1000/152/248/66',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.tag.seclang
+#                              ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                               ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    ver:'OWASP_CRS/4.27.0-dev',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang
+#                             ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                              ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                               ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    severity:'CRITICAL',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#             ^ source.seclang meta.action-list.seclang punctuation.definition.string.seclang
+#              ^^^^^^^^ source.seclang meta.action-list.seclang constant.language.severity.seclang
+#                      ^ source.seclang meta.action-list.seclang punctuation.definition.string.seclang
+#                       ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                        ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#           ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#            ^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                                  ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang keyword.operator.assignment.seclang
+#                                   ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                                    ^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                      ^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                        ^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang variable.other.macro.key.seclang
+#                                                               ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                                ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                                 ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                  ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#           ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                                        ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang keyword.operator.assignment.seclang
+#                                         ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                                          ^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                            ^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                              ^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang variable.other.macro.key.seclang
+#                                                                     ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                                      ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                                       ^ source.seclang meta.action-list.seclang
+>

--- a/test/highlight/snap/edge-cases.conf
+++ b/test/highlight/snap/edge-cases.conf
@@ -1,0 +1,94 @@
+# SecLang highlighting edge-case corpus.
+# Synthetic but valid-shaped rules that stress the TextMate grammar:
+# operators, negation, variable selectors, macros, ctl/setvar, quoting,
+# continuations (indented and column-0), transformations, and directives.
+
+# ── Operators: presence, arguments, negation, no-arg ────────────────────────
+SecRule ARGS "@rx attack" "id:1,phase:2,deny"
+SecRule ARGS "@detectSQLi" "id:2,phase:2,deny"
+SecRule ARGS "!@rx ^$" "id:3,phase:2,pass"
+SecRule REQBODY_ERROR "!@eq 0" "id:4,phase:2,deny,severity:2"
+SecRule ARGS "@pmFromFile lfi-os-files.data" "id:5,phase:1,pass"
+SecRule ARGS "@within %{tx.allowed_methods}" "id:6,phase:1,pass"
+SecRule ARGS "@rx a#b#c" "id:7,phase:2,pass"
+SecRule ARGS "@rx attack\"vector" "id:8,phase:2,pass"
+SecRule ARGS "@rx it's a (?i:test)" "id:9,phase:2,pass"
+SecRule ARGS "@rx \d{1,5}" "id:10,phase:2,pass"
+
+# ── Variables: selectors, counts, negation, regex selectors, lists, XML ─────
+SecRule ARGS:user "@rx x" "id:20,phase:2,pass"
+SecRule ARGS:'user name' "@rx x" "id:21,phase:2,pass"
+SecRule &ARGS "@eq 0" "id:22,phase:2,pass"
+SecRule !ARGS:password "@rx x" "id:23,phase:2,pass"
+SecRule REQUEST_HEADERS:/^X-Forwarded/ "@rx x" "id:24,phase:1,pass"
+SecRule ARGS|ARGS_NAMES|!ARGS:secret "@rx x" "id:25,phase:2,pass"
+SecRule XML:/* "@rx x" "id:26,phase:2,pass"
+SecRule XML://@attr "@rx x" "id:27,phase:2,pass"
+SecRule TX:anomaly_score "@gt 5" "id:28,phase:5,pass"
+
+# ── Transformations (chained) ───────────────────────────────────────────────
+SecRule ARGS "@rx x" "id:30,phase:2,t:none,t:lowercase,t:urlDecodeUni,t:removeNulls,t:compressWhitespace,pass"
+
+# ── Macros in msg / logdata / setvar; key forms .key and :key ───────────────
+SecRule ARGS "@rx x" \
+    "id:31,phase:2,pass,\
+    msg:'Matched %{TX.0} in %{MATCHED_VAR_NAME}',\
+    logdata:'val=%{MATCHED_VAR} score=%{tx.anomaly_score}',\
+    setvar:'tx.score=+%{tx.critical_anomaly_score}'"
+SecRule GEO:COUNTRY_CODE "@streq CN" "id:32,phase:1,deny,setvar:tx.block=1"
+
+# ── setvar / setenv / expirevar / initcol variants (quoted + unquoted) ──────
+SecAction "id:40,phase:1,pass,nolog,setvar:tx.paranoia_level=1"
+SecAction "id:41,phase:1,pass,nolog,setvar:!tx.foo"
+SecAction "id:42,phase:1,pass,nolog,expirevar:tx.foo=60"
+SecAction "id:43,phase:1,pass,nolog,initcol:ip=%{REMOTE_ADDR}"
+SecAction "id:44,phase:1,pass,nolog,setenv:'TESTING=1'"
+
+# ── ctl variants ────────────────────────────────────────────────────────────
+SecRule ARGS "@rx x" "id:50,phase:1,pass,ctl:ruleEngine=Off"
+SecRule ARGS "@rx x" "id:51,phase:1,pass,ctl:auditLogParts=+E"
+SecRule ARGS "@rx x" "id:52,phase:1,pass,ctl:ruleRemoveTargetById=981176;ARGS:foo"
+
+# ── id / severity / phase: quoted, unquoted, word, last-action ──────────────
+SecRule ARGS "@rx x" "phase:request,pass,id:60"
+SecRule ARGS "@rx x" "id:'61',phase:logging,pass,severity:'CRITICAL'"
+SecRule ARGS "@rx x" "id:62,phase:2,pass,severity:WARNING"
+SecRule ARGS "@rx x" "id:63,phase:2,pass,severity:2"
+SecRule ARGS "@rx x" "phase:2,pass,severity:2,id:64"
+
+# ── Chained rules (child has no id) ─────────────────────────────────────────
+SecRule ARGS "@rx x" "id:70,phase:2,chain,deny"
+    SecRule REQUEST_METHOD "@streq POST" "t:none"
+
+# ── Column-0 continuation (ModSecurity style) ───────────────────────────────
+SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
+"id:80,phase:2,t:none,log,deny,status:400, \
+msg:'Multipart failed: PE %{REQBODY_PROCESSOR_ERROR}, BQ %{MULTIPART_BOUNDARY_QUOTED}',\
+severity:2"
+
+# ── Operator split onto its own continuation line ───────────────────────────
+SecRule ARGS \
+    "@rx (?i:union[\s]+select)" \
+    "id:81,phase:2,deny,msg:'SQLi'"
+
+# ── Directives that take rule-id ranges / tags ──────────────────────────────
+SecRuleRemoveById 942100
+SecRuleRemoveById 942100-942999
+SecRuleRemoveByTag "attack-sqli"
+SecRuleUpdateTargetById 942100 "!ARGS:foo"
+SecRuleUpdateActionById 942100 "t:none,deny"
+
+# ── Markers (bare + quoted) ─────────────────────────────────────────────────
+SecMarker END-REQUEST-942-APPLICATION-ATTACK-SQLI
+SecMarker "BEGIN SECTION"
+SecRule ARGS "@rx x" "id:90,phase:2,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+
+# ── Includes / config directives ────────────────────────────────────────────
+Include /etc/crs/rules/*.conf
+Include rules/local.conf
+SecRuleEngine DetectionOnly
+SecDefaultAction "phase:2,log,auditlog,pass"
+SecComponentSignature "OWASP_CRS/4.0.0"
+
+# ── msg containing escaped single quote and escaped double quote ────────────
+SecRule ARGS "@rx x" "id:100,phase:2,pass,msg:'it\'s the \"magic\" value'"

--- a/test/highlight/snap/edge-cases.conf.snap
+++ b/test/highlight/snap/edge-cases.conf.snap
@@ -1,0 +1,1079 @@
+># SecLang highlighting edge-case corpus.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+># Synthetic but valid-shaped rules that stress the TextMate grammar:
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+># operators, negation, variable selectors, macros, ctl/setvar, quoting,
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+># continuations (indented and column-0), transformations, and directives.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>
+># ── Operators: presence, arguments, negation, no-arg ────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx attack" "id:1,phase:2,deny"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                        ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                         ^ source.seclang meta.rule.seclang
+#                          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                              ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                               ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                        ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@detectSQLi" "id:2,phase:2,deny"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                         ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                          ^ source.seclang meta.rule.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                            ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                               ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "!@rx ^$" "id:3,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang keyword.operator.seclang
+#               ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                  ^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                     ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                      ^ source.seclang meta.rule.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                        ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                            ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                             ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                     ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule REQBODY_ERROR "!@eq 0" "id:4,phase:2,deny,severity:2"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                     ^ source.seclang meta.rule.seclang
+#                      ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                       ^ source.seclang meta.rule.seclang meta.operator.seclang keyword.operator.seclang
+#                        ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                           ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                              ^ source.seclang meta.rule.seclang
+#                               ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                     ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                             ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                  ^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.language.severity.seclang
+#                                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@pmFromFile lfi-os-files.data" "id:5,phase:1,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                         ^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                            ^ source.seclang meta.rule.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                              ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                   ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                           ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@within %{tx.allowed_methods}" "id:6,phase:1,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                     ^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                            ^ source.seclang meta.rule.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                              ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                   ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                           ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx a#b#c" "id:7,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                       ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                        ^ source.seclang meta.rule.seclang
+#                         ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                          ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                              ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                               ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                       ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx attack\"vector" "id:8,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                 ^ source.seclang meta.rule.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                   ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                        ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx it's a (?i:test)" "id:9,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                   ^ source.seclang meta.rule.seclang
+#                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                     ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                          ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                  ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx \d{1,5}" "id:10,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^^^^^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                         ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                          ^ source.seclang meta.rule.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                            ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                               ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                  ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                          ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── Variables: selectors, counts, negation, regex selectors, lists, XML ─────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS:user "@rx x" "id:20,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#             ^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                 ^ source.seclang meta.rule.seclang
+#                  ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                    ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                      ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                        ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                         ^ source.seclang meta.rule.seclang
+#                          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                              ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS:'user name' "@rx x" "id:21,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#             ^^^^^^^^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                        ^ source.seclang meta.rule.seclang
+#                         ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                          ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                           ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                             ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                               ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                ^ source.seclang meta.rule.seclang
+#                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                  ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                     ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                        ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule &ARGS "@eq 0" "id:22,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^ source.seclang meta.rule.seclang keyword.operator.variable.seclang
+#         ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#             ^ source.seclang meta.rule.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang
+#               ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                  ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                    ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                     ^ source.seclang meta.rule.seclang
+#                      ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                       ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                          ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                            ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                             ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                     ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule !ARGS:password "@rx x" "id:23,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^ source.seclang meta.rule.seclang keyword.operator.variable.seclang
+#         ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#             ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#              ^^^^^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                      ^ source.seclang meta.rule.seclang
+#                       ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                        ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                           ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                              ^ source.seclang meta.rule.seclang
+#                               ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                   ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                      ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                              ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule REQUEST_HEADERS:/^X-Forwarded/ "@rx x" "id:24,phase:1,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                       ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#                        ^^^^^^^^^^^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                                      ^ source.seclang meta.rule.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                         ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                           ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                              ^ source.seclang meta.rule.seclang
+#                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                                ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                   ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                      ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                              ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS|ARGS_NAMES|!ARGS:secret "@rx x" "id:25,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang punctuation.separator.variable.seclang
+#             ^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                       ^ source.seclang meta.rule.seclang punctuation.separator.variable.seclang
+#                        ^ source.seclang meta.rule.seclang keyword.operator.variable.seclang
+#                         ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                             ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#                              ^^^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                                    ^ source.seclang meta.rule.seclang
+#                                     ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                      ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                       ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                         ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                            ^ source.seclang meta.rule.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                              ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                 ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                    ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                            ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                                ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule XML:/* "@rx x" "id:26,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#           ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#            ^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#              ^ source.seclang meta.rule.seclang
+#               ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                   ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                     ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                      ^ source.seclang meta.rule.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                        ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                           ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                      ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule XML://@attr "@rx x" "id:27,phase:2,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#           ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#            ^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#              ^ source.seclang meta.rule.seclang
+#               ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                   ^ source.seclang meta.rule.seclang
+#                    ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                     ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                      ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                        ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                          ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                           ^ source.seclang meta.rule.seclang
+#                            ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                             ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                   ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                           ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule TX:anomaly_score "@gt 5" "id:28,phase:5,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#          ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#           ^^^^^^^^^^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                        ^ source.seclang meta.rule.seclang
+#                         ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                          ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                           ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                             ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                               ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                ^ source.seclang meta.rule.seclang
+#                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                  ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                     ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                        ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                               ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── Transformations (chained) ───────────────────────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx x" "id:30,phase:2,t:none,t:lowercase,t:urlDecodeUni,t:removeNulls,t:compressWhitespace,pass"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                      ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang support.function.builtin.seclang
+#                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                           ^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                             ^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang support.function.builtin.seclang
+#                                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                       ^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                         ^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang support.function.builtin.seclang
+#                                                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                      ^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                                        ^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang support.function.builtin.seclang
+#                                                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                                    ^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                                                      ^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang support.function.builtin.seclang
+#                                                                                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                                                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                                                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── Macros in msg / logdata / setvar; key forms .key and :key ───────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx x" \
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang punctuation.separator.continuation.seclang
+>    "id:31,phase:2,pass,\
+#^^^^^ source.seclang meta.action-list.seclang
+#     ^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#          ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#           ^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                 ^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#                  ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                   ^^^^ source.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                       ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                        ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    msg:'Matched %{TX.0} in %{MATCHED_VAR_NAME}',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#         ^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                 ^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                   ^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                     ^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang variable.other.macro.key.seclang
+#                       ^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                        ^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                            ^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                              ^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                              ^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                               ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                 ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    logdata:'val=%{MATCHED_VAR} score=%{tx.anomaly_score}',\
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#            ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#             ^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang
+#                 ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                   ^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                              ^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                               ^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang
+#                                      ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                        ^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                          ^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang variable.other.macro.key.seclang
+#                                                        ^ source.seclang meta.action-list.seclang string.quoted.single.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                         ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                          ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                           ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>    setvar:'tx.score=+%{tx.critical_anomaly_score}'"
+#^^^^ source.seclang meta.action-list.seclang
+#    ^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#           ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#            ^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                    ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang keyword.operator.assignment.seclang
+#                     ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                      ^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                        ^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                          ^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang variable.other.macro.key.seclang
+#                                                 ^ source.seclang meta.action-list.seclang string.quoted.single.setvar.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                  ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                   ^ source.seclang meta.action-list.seclang
+>SecRule GEO:COUNTRY_CODE "@streq CN" "id:32,phase:1,deny,setvar:tx.block=1"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#           ^ source.seclang meta.rule.seclang punctuation.separator.key.seclang
+#            ^^^^^^^^^^^^ source.seclang meta.rule.seclang variable.parameter.selector.seclang
+#                        ^ source.seclang meta.rule.seclang
+#                         ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                          ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                           ^^^^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                ^^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                    ^ source.seclang meta.rule.seclang
+#                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                         ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                                ^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang variable.other.seclang
+#                                                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.operator.assignment.seclang
+#                                                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.setvar-value.seclang
+#                                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── setvar / setenv / expirevar / initcol variants (quoted + unquoted) ──────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecAction "id:40,phase:1,pass,nolog,setvar:tx.paranoia_level=1"
+#^^^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#         ^ source.seclang meta.rule.seclang
+#          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#              ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                           ^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang variable.other.seclang
+#                                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.operator.assignment.seclang
+#                                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.setvar-value.seclang
+#                                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecAction "id:41,phase:1,pass,nolog,setvar:!tx.foo"
+#^^^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#         ^ source.seclang meta.rule.seclang
+#          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#              ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                           ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.action-value.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecAction "id:42,phase:1,pass,nolog,expirevar:tx.foo=60"
+#^^^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#         ^ source.seclang meta.rule.seclang
+#          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#              ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                              ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang variable.other.seclang
+#                                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.operator.assignment.seclang
+#                                                     ^^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.setvar-value.seclang
+#                                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecAction "id:43,phase:1,pass,nolog,initcol:ip=%{REMOTE_ADDR}"
+#^^^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#         ^ source.seclang meta.rule.seclang
+#          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#              ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                            ^^^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.action-value.seclang
+#                                               ^^ source.seclang meta.rule.seclang meta.action-list.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                                 ^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecAction "id:44,phase:1,pass,nolog,setenv:'TESTING=1'"
+#^^^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#         ^ source.seclang meta.rule.seclang
+#          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#           ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#              ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                 ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                       ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#                                            ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang string.quoted.single.setvar.seclang keyword.operator.assignment.seclang
+#                                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang string.quoted.single.setvar.seclang
+#                                                     ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── ctl variants ────────────────────────────────────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx x" "id:50,phase:1,pass,ctl:ruleEngine=Off"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                             ^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                       ^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.operator.assignment.seclang
+#                                                        ^^^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.seclang
+#                                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx x" "id:51,phase:1,pass,ctl:auditLogParts=+E"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                             ^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.operator.assignment.seclang
+#                                                           ^^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.seclang
+#                                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx x" "id:52,phase:1,pass,ctl:ruleRemoveTargetById=981176;ARGS:foo"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                             ^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.operator.assignment.seclang
+#                                                                  ^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang string.unquoted.seclang
+#                                                                                 ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── id / severity / phase: quoted, unquoted, word, last-action ──────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx x" "phase:request,pass,id:60"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                            ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                            ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx x" "id:'61',phase:logging,pass,severity:'CRITICAL'"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.seclang
+#                          ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                            ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                    ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                            ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                                ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                 ^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.seclang
+#                                                           ^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.language.severity.seclang
+#                                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.seclang
+#                                                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx x" "id:62,phase:2,pass,severity:WARNING"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                  ^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.language.severity.seclang
+#                                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx x" "id:63,phase:2,pass,severity:2"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.language.severity.seclang
+#                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecRule ARGS "@rx x" "phase:2,pass,severity:2,id:64"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                            ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                   ^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                            ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.language.severity.seclang
+#                                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                              ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                 ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── Chained rules (child has no id) ─────────────────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx x" "id:70,phase:2,chain,deny"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                          ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>    SecRule REQUEST_METHOD "@streq POST" "t:none"
+#^^^^ source.seclang meta.directive.seclang
+#    ^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>
+># ── Column-0 continuation (ModSecurity style) ───────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#                              ^ source.seclang meta.rule.seclang
+#                               ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                ^ source.seclang meta.rule.seclang meta.operator.seclang keyword.operator.seclang
+#                                 ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                  ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                                    ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                                      ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                                       ^ source.seclang meta.rule.seclang
+#                                        ^ source.seclang meta.rule.seclang punctuation.separator.continuation.seclang
+>"id:80,phase:2,t:none,log,deny,status:400, \
+#^ source.seclang meta.action-list.seclang
+# ^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#    ^^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#      ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#       ^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#             ^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#              ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#               ^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                 ^^^^ source.seclang meta.action-list.seclang support.function.builtin.seclang
+#                     ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                      ^^^ source.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                         ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                          ^^^^ source.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                              ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                               ^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                      ^^^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#                                         ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                          ^ source.seclang meta.action-list.seclang
+#                                           ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>msg:'Multipart failed: PE %{REQBODY_PROCESSOR_ERROR}, BQ %{MULTIPART_BOUNDARY_QUOTED}',\
+#^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#    ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#     ^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                          ^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                            ^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                                   ^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                    ^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                                                         ^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.begin.seclang
+#                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang variable.other.macro.collection.seclang
+#                                                                                    ^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang meta.macro.seclang punctuation.definition.macro.end.seclang
+#                                                                                     ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                                                      ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                                                                       ^ source.seclang meta.action-list.seclang punctuation.separator.continuation.seclang
+>severity:2"
+#^^^^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#         ^ source.seclang meta.action-list.seclang constant.language.severity.seclang
+#          ^ source.seclang meta.action-list.seclang
+>
+># ── Operator split onto its own continuation line ───────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS \
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang punctuation.separator.continuation.seclang
+>    "@rx (?i:union[\s]+select)" \
+#^^^^^ source.seclang meta.operator.seclang
+#     ^ source.seclang meta.operator.seclang entity.name.function.seclang
+#      ^^ source.seclang meta.operator.seclang entity.name.function.seclang
+#        ^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.operator.seclang string.quoted.double.seclang
+#                              ^ source.seclang meta.operator.seclang
+#                               ^^^ source.seclang
+>    "id:81,phase:2,deny,msg:'SQLi'"
+#^^^^^ source.seclang meta.action-list.seclang
+#     ^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#        ^^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#          ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#           ^^^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                 ^ source.seclang meta.action-list.seclang constant.numeric.seclang
+#                  ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                   ^^^^ source.seclang meta.action-list.seclang keyword.control.disruptive.seclang
+#                       ^ source.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                        ^^^^ source.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                            ^ source.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#                             ^^^^ source.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                                 ^ source.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                  ^ source.seclang meta.action-list.seclang
+>
+># ── Directives that take rule-id ranges / tags ──────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRuleRemoveById 942100
+#^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#                 ^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecRuleRemoveById 942100-942999
+#^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#                 ^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecRuleRemoveByTag "attack-sqli"
+#^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#                  ^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecRuleUpdateTargetById 942100 "!ARGS:foo"
+#^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#                       ^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecRuleUpdateActionById 942100 "t:none,deny"
+#^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#                       ^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>
+># ── Markers (bare + quoted) ─────────────────────────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecMarker END-REQUEST-942-APPLICATION-ATTACK-SQLI
+#^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecMarker "BEGIN SECTION"
+#^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#         ^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecRule ARGS "@rx x" "id:90,phase:2,pass,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                           ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                            ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                    ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                        ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                         ^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.name.label.seclang
+#                                                                                          ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>
+># ── Includes / config directives ────────────────────────────────────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>Include /etc/crs/rules/*.conf
+#^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#       ^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>Include rules/local.conf
+#^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#       ^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecRuleEngine DetectionOnly
+#^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#             ^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>SecDefaultAction "phase:2,log,auditlog,pass"
+#^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#                ^ source.seclang meta.rule.seclang
+#                 ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                  ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                        ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                         ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                          ^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                             ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                              ^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                      ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                       ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                           ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>SecComponentSignature "OWASP_CRS/4.0.0"
+#^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang keyword.control.directive.seclang
+#                     ^^^^^^^^^^^^^^^^^^ source.seclang meta.directive.seclang string.unquoted.seclang
+>
+># ── msg containing escaped single quote and escaped double quote ────────────
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.seclang comment.line.number-sign.seclang
+>SecRule ARGS "@rx x" "id:100,phase:2,pass,msg:'it\'s the \"magic\" value'"
+#^^^^^^^ source.seclang meta.rule.seclang keyword.control.directive.seclang
+#       ^ source.seclang meta.rule.seclang
+#        ^^^^ source.seclang meta.rule.seclang entity.name.class.seclang
+#            ^ source.seclang meta.rule.seclang
+#             ^ source.seclang meta.rule.seclang meta.operator.seclang
+#              ^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#               ^^ source.seclang meta.rule.seclang meta.operator.seclang entity.name.function.seclang
+#                 ^^ source.seclang meta.rule.seclang meta.operator.seclang string.quoted.double.seclang
+#                   ^ source.seclang meta.rule.seclang meta.operator.seclang
+#                    ^ source.seclang meta.rule.seclang
+#                     ^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                      ^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                         ^^^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                            ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                             ^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                   ^ source.seclang meta.rule.seclang meta.action-list.seclang constant.numeric.seclang
+#                                    ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                     ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang keyword.control.flow.seclang
+#                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.separator.comma.seclang
+#                                          ^^^^ source.seclang meta.rule.seclang meta.action-list.seclang entity.other.attribute-name.seclang
+#                                              ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.begin.seclang
+#                                               ^^^ source.seclang meta.rule.seclang meta.action-list.seclang string.quoted.single.msg.seclang
+#                                                  ^ source.seclang meta.rule.seclang meta.action-list.seclang punctuation.definition.string.end.seclang
+#                                                   ^^^^^^^^^^^^^^^^^^^^^^ source.seclang meta.rule.seclang meta.action-list.seclang
+#                                                                         ^ source.seclang meta.rule.seclang meta.action-list.seclang
+>

--- a/test/highlight/tokenize.mjs
+++ b/test/highlight/tokenize.mjs
@@ -1,0 +1,32 @@
+// Copyright 2026 OWASP Coraza
+// SPDX-License-Identifier: Apache-2.0
+//
+// CLI: tokenize a single SecLang file and print every token with its scopes.
+// Usage: node tokenize.mjs <file> [--json]
+import { readFile } from "node:fs/promises";
+import { tokenizeText } from "./lib/grammar.mjs";
+
+const args = process.argv.slice(2);
+const json = args.includes("--json");
+const file = args.find((a) => !a.startsWith("--"));
+if (!file) {
+  console.error("usage: node tokenize.mjs <file> [--json]");
+  process.exit(2);
+}
+
+const text = await readFile(file, "utf8");
+const lines = await tokenizeText(text);
+
+if (json) {
+  console.log(JSON.stringify(lines, null, 2));
+} else {
+  lines.forEach((toks, i) => {
+    for (const t of toks) {
+      if (t.text.trim() === "") continue;
+      const scope = t.scopes.slice(1).join(" ") || "(none — fallthrough)";
+      console.log(
+        `${String(i + 1).padStart(4)}:${String(t.startIndex).padStart(3)}  ${JSON.stringify(t.text).padEnd(28)}  ${scope}`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
## What

Audited the SecLang **TextMate grammar** against real-world rulesets by tokenizing with the exact engine VS Code ships (`vscode-textmate` + Oniguruma). Found and fixed **6 classes of highlighting bug**, and added a test harness + snapshots so they can't regress.

Corpus swept (now **0 highlighting holes** on all): full OWASP CRS (27 files / 14k lines), ModSecurity example rules, Coraza engine test corpus, and a hand-written edge-case fixture.

## Grammar fixes — `editors/vscode/syntaxes/seclang.tmLanguage.json`

1. **Escaped quote breaks the rest of a rule** — `\"` inside a single-quoted `msg:'…'` value terminated the action-list region (CRS rule 942220 et al.). Region end now uses a negative lookbehind `(?<!\\)"`.
2. **`action-key` ate leading whitespace** — on indented continuation lines it out-raced the specific `msg`/`id`/`severity`/… rules. Now uses a non-consuming lookbehind.
3. **Column-0 continuations not highlighted** — the canonical `modsecurity.conf` style (`^"…`). Continuations now accept `\s*`.
4. **Trailing optional quote swallowed the region terminator** — `…,severity:2"` / `…,id:1"`. Quotes now matched as a balanced pair.
5. **`t:` transformations never scoped** — rule was ordered after the generic value rule. Reordered + anchored.
6. **Variable targets** — `|` separator, `&`/`!` modifiers and `:selector` (plain / `'quoted'` / `/regex/`) now scoped distinctly, per the [coraza.io](https://coraza.io/docs/seclang/variables/) syntax; a `/`-prefixed non-regex selector (`XML:/*`) no longer bleeds into the operator string.

## vim — `editors/vim/syntax/seclang.vim`

Verified with Neovim that the vim region model already handles `\"` and column-0 continuations (no break). Added `syntax sync minlines=50` so long multi-line rules highlight correctly when scrolled into.

## Tests

- **`test/highlight/`** — node harness: `tokenize.mjs` (dump scopes), `audit.mjs` (flags *holes* = tokens with no scope beyond root), `vscode-tmgrammar-snap` snapshots (catch *wrong* scopes — e.g. the transformation bug), edge-case fixtures. `npm test` is the CI gate.
- **`editors/vim/test/spec/syntax_spec.lua`** — Neovim plenary regression spec.
- **`.github/workflows/editors.yml`** — new `grammar-tests` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)