### PR TITLE
fix(lsp): unblock config lock, fix races, doublestar globs, harden transports

### DIFF
--- a/cmd/coraza-lsp/main.go
+++ b/cmd/coraza-lsp/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/tliron/commonlog"
@@ -60,9 +61,9 @@ func main() {
 	var err error
 	switch {
 	case *tcpAddr != "":
-		err = srv.RunTCP(*tcpAddr)
+		err = srv.RunTCP(loopbackAddr(*tcpAddr))
 	case *wsAddr != "":
-		err = srv.RunWebSocket(*wsAddr)
+		err = srv.RunWebSocket(loopbackAddr(*wsAddr))
 	default: // --stdio is the default (also when --stdio flag is explicitly set)
 		_ = useStdio
 		err = srv.RunStdio()
@@ -72,4 +73,21 @@ func main() {
 		fmt.Fprintf(os.Stderr, "coraza-lsp: fatal: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// loopbackAddr defaults a bare port / wildcard bind to loopback. The TCP and
+// WebSocket transports are dev-only and have no/limited per-message size
+// guards (see pkg/lsp), so binding them to all interfaces would expose the LSP
+// — including its on-disk file-read behaviour — to the local network. If the
+// user provides an explicit host we honour it; only a missing or wildcard host
+// (e.g. ":7998" or "0.0.0.0:7998") is rewritten to 127.0.0.1.
+func loopbackAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr // leave malformed input for the listener to reject
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/coraza-incubator/coraza-lsp
 go 1.25.0
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/corazawaf/coraza/v3 v3.5.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gorilla/websocket v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc h1:OlJhrgI3I+FLUCTI3JJW8MoqyM78WbqJjecqMnqG+wc=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
 github.com/corazawaf/coraza/v3 v3.5.0 h1:zGYW3cKhDa05Ztdt7+SGp7OkmR9AgxOFfLbDPwi0Y5M=

--- a/pkg/lsp/config.go
+++ b/pkg/lsp/config.go
@@ -34,12 +34,7 @@ type configState struct {
 // A missing config is not an error — the server falls back to defaults.
 // Errors in the file are surfaced via onError (typically a window/showMessage).
 func (s *Server) LoadConfig(workspaceRoot string, onError func(msg string)) {
-	s.cfgState.mu.Lock()
-	defer s.cfgState.mu.Unlock()
-
-	s.cfgState.root = workspaceRoot
 	path := config.DiscoverFS(s.fs, workspaceRoot)
-	s.cfgState.path = path
 
 	cfg := config.Default()
 	if path != "" {
@@ -57,15 +52,28 @@ func (s *Server) LoadConfig(workspaceRoot string, onError func(msg string)) {
 		}
 	}
 
+	// Install the parsed config + derived options under a short write lock.
+	// We snapshot the bits indexWorkspace needs (root, patterns) and release
+	// the lock BEFORE walking the workspace — otherwise the (potentially
+	// multi-second) index build would block every concurrent request, since
+	// Config()/analysisOptions() are on the hot path of every diagnostic run.
+	s.cfgState.mu.Lock()
+	s.cfgState.root = workspaceRoot
+	s.cfgState.path = path
 	s.cfgState.cfg = cfg
 	s.cfgState.opts = optionsFromConfig(cfg)
+	doIndex := cfg.Global && workspaceRoot != ""
+	patterns := cfg.FilePatterns
+	ignore := cfg.Ignore
+	s.cfgState.mu.Unlock()
 
-	// Kick off (or clear) the workspace index. Runs synchronously because
-	// LoadConfig is already called from a background-friendly place
-	// (initialize handler + the watcher goroutine). For large workspaces
-	// users can flip global:false to skip this cost.
-	if cfg.Global && workspaceRoot != "" {
-		idx := indexWorkspace(s.fs, workspaceRoot, cfg.FilePatterns, cfg.Ignore)
+	// Build (or clear) the workspace index WITHOUT holding the config lock.
+	// SetIndex has its own mutex and swaps the result in atomically. The scan
+	// is synchronous here because LoadConfig is already called from a
+	// background-friendly place (the initialize handler + the watcher
+	// goroutine), and callers expect the index to be ready on return.
+	if doIndex {
+		idx := indexWorkspace(s.fs, workspaceRoot, patterns, ignore)
 		s.store.SetIndex(idx)
 	} else {
 		s.store.SetIndex(nil)
@@ -77,6 +85,15 @@ func (s *Server) Config() config.Config {
 	s.cfgState.mu.RLock()
 	defer s.cfgState.mu.RUnlock()
 	return s.cfgState.cfg
+}
+
+// configRoot returns the workspace root the config is currently scoped to,
+// read under the mutex. watchLoop must use this rather than touching
+// s.cfgState.root directly, which LoadConfig writes under the lock.
+func (s *Server) configRoot() string {
+	s.cfgState.mu.RLock()
+	defer s.cfgState.mu.RUnlock()
+	return s.cfgState.root
 }
 
 // analysisOptions returns the derived analysis.Options. Used on every
@@ -93,7 +110,13 @@ func optionsFromConfig(cfg config.Config) analysis.Options {
 	}
 	return analysis.Options{
 		SeverityOverrides: cfg.Diagnostics,
-		EntrypointAware:   cfg.Entrypoint != "",
+		// EntrypointAware is populated for forward-compatibility but is NOT
+		// yet consumed by the analyser (no cross-file severity promotion, no
+		// resolvability check) — see the doc on analysis.Options.EntrypointAware.
+		// Wiring it up is a larger change tracked separately; we set it from a
+		// plain non-empty check so the field reflects intent without implying
+		// behaviour that doesn't exist.
+		EntrypointAware: cfg.Entrypoint != "",
 	}
 }
 
@@ -195,7 +218,7 @@ func (s *Server) watchLoop(w *fsnotify.Watcher, stop <-chan struct{}, onChange f
 			}
 		case <-reload:
 			old := s.Config()
-			s.LoadConfig(s.cfgState.root, onError)
+			s.LoadConfig(s.configRoot(), onError)
 			if onChange != nil {
 				onChange(old, s.Config())
 			}

--- a/pkg/lsp/crossfile.go
+++ b/pkg/lsp/crossfile.go
@@ -34,33 +34,28 @@ func (s *Server) augmentCrossFile(uri string, doc *parser.File, base []protocol.
 		}
 	}
 
-	all := s.store.AllASTs()
-	// Index of "id → (uri, range)" from every *other* file.
-	type hit struct {
-		uri string
-		rng parser.Range
-	}
-	byID := make(map[string]hit)
-	for otherURI, f := range all {
-		if otherURI == uri || f == nil {
-			continue
-		}
-		for _, n := range f.Nodes {
-			rule, ok := n.(*parser.RuleNode)
-			if !ok {
-				continue
-			}
-			id := rule.FindAction("id")
-			if id == nil {
-				continue
-			}
-			if _, set := byID[id.Value]; !set {
-				byID[id.Value] = hit{uri: otherURI, rng: id.Range}
-			}
-		}
-	}
-	if len(byID) == 0 {
+	// Workspace-wide id index, cached and incrementally maintained by the
+	// DocumentStore rather than rebuilt from every file on each call.
+	xf := s.store.CrossFileIDs()
+	if len(xf) == 0 {
 		return base
+	}
+
+	// otherDefiner returns the URI/range of a file *other than* uri that also
+	// defines id, or ok=false when no other file does.
+	otherDefiner := func(id string) (string, parser.Range, bool) {
+		e, ok := xf[id]
+		if !ok || e.count == 0 {
+			return "", parser.Range{}, false
+		}
+		if e.uri1 != uri {
+			return e.uri1, e.rng1, true
+		}
+		// uri itself is the first definer; a second distinct file makes it a dup.
+		if e.count >= 2 {
+			return e.uri2, e.rng2, true
+		}
+		return "", parser.Range{}, false
 	}
 
 	severity := protocol.DiagnosticSeverityError
@@ -87,7 +82,7 @@ func (s *Server) augmentCrossFile(uri string, doc *parser.File, base []protocol.
 		if id == nil {
 			continue
 		}
-		other, ok := byID[id.Value]
+		otherURI, _, ok := otherDefiner(id.Value)
 		if !ok {
 			continue
 		}
@@ -100,7 +95,7 @@ func (s *Server) augmentCrossFile(uri string, doc *parser.File, base []protocol.
 			Code:     &code,
 			Message: fmt.Sprintf(
 				"duplicate rule id %s (also defined in %s)",
-				id.Value, other.uri),
+				id.Value, otherURI),
 		})
 	}
 	return out

--- a/pkg/lsp/documents.go
+++ b/pkg/lsp/documents.go
@@ -17,6 +17,9 @@ type Document struct {
 	Version int32
 	Content string
 	AST     *parser.File
+	// Lines is Content split on "\n", computed once at Open time so per-request
+	// features (completion) don't re-split the whole document on every call.
+	Lines []string
 }
 
 // DocumentStore is a thread-safe store for open LSP documents plus, when
@@ -28,6 +31,27 @@ type DocumentStore struct {
 	mu      sync.RWMutex
 	docs    map[string]*Document
 	indexed map[string]*indexedFile // populated by SetIndex when Global is true
+
+	// ruleIDs caches each file's rule-id → Range contribution, computed once
+	// when the file's AST changes (Open/Change/SetIndex) rather than rescanned
+	// on every cross-file diagnostic run. Keyed by URI; open docs override
+	// indexed files with the same URI (handled at merge time below).
+	ruleIDs    map[string]map[string]parser.Range
+	xfGen      uint64                      // bumped whenever ruleIDs changes
+	xfCacheGen uint64                      // generation xfCache was built at
+	xfCache    map[string]crossFileIDEntry // merged id → up-to-two locations
+}
+
+// crossFileIDEntry records, for one rule id, where it is defined across the
+// whole workspace: the count of distinct files plus up to two (uri, range)
+// samples so augmentCrossFile can report an "other" file even when the current
+// file is one of the definers.
+type crossFileIDEntry struct {
+	count int
+	uri1  string
+	rng1  parser.Range
+	uri2  string
+	rng2  parser.Range
 }
 
 // NewDocumentStore returns an empty DocumentStore.
@@ -35,18 +59,108 @@ func NewDocumentStore() *DocumentStore {
 	return &DocumentStore{
 		docs:    make(map[string]*Document),
 		indexed: make(map[string]*indexedFile),
+		ruleIDs: make(map[string]map[string]parser.Range),
 	}
+}
+
+// ruleIDsFromAST extracts the rule-id → id-action Range map from a parsed file.
+// First definition of a given id within the file wins (mirrors the previous
+// augmentCrossFile behaviour).
+func ruleIDsFromAST(f *parser.File) map[string]parser.Range {
+	if f == nil {
+		return nil
+	}
+	var ids map[string]parser.Range
+	for _, n := range f.Nodes {
+		rule, ok := n.(*parser.RuleNode)
+		if !ok {
+			continue
+		}
+		id := rule.FindAction("id")
+		if id == nil {
+			continue
+		}
+		if ids == nil {
+			ids = make(map[string]parser.Range)
+		}
+		if _, set := ids[id.Value]; !set {
+			ids[id.Value] = id.Range
+		}
+	}
+	return ids
+}
+
+// setRuleIDs records a file's id contribution and invalidates the merged
+// cache. Caller must hold mu.
+func (s *DocumentStore) setRuleIDs(uri string, f *parser.File) {
+	ids := ruleIDsFromAST(f)
+	if ids == nil {
+		delete(s.ruleIDs, uri)
+	} else {
+		s.ruleIDs[uri] = ids
+	}
+	s.xfGen++
+}
+
+// CrossFileIDs returns, for each rule id known across the workspace, where it
+// is defined (count + sample locations). The merged map is cached and only
+// rebuilt when a file's id set changes, so the common case (repeated diagnostic
+// runs between edits) is O(1) plus a copy. Open documents shadow indexed files
+// with the same URI because Open/SetIndex feed the same ruleIDs map keyed by
+// URI.
+func (s *DocumentStore) CrossFileIDs() map[string]crossFileIDEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.xfCache == nil || s.xfCacheGen != s.xfGen {
+		merged := make(map[string]crossFileIDEntry)
+		for uri, ids := range s.ruleIDs {
+			for id, rng := range ids {
+				e := merged[id]
+				e.count++
+				switch e.count {
+				case 1:
+					e.uri1, e.rng1 = uri, rng
+				case 2:
+					e.uri2, e.rng2 = uri, rng
+				}
+				merged[id] = e
+			}
+		}
+		s.xfCache = merged
+		s.xfCacheGen = s.xfGen
+	}
+	// Return a copy so callers can read it without holding the lock.
+	out := make(map[string]crossFileIDEntry, len(s.xfCache))
+	for id, e := range s.xfCache {
+		out[id] = e
+	}
+	return out
 }
 
 // SetIndex replaces the indexed (closed-file) set wholesale. Called by the
 // workspace scanner after LoadConfig / after a config reload.
 func (s *DocumentStore) SetIndex(idx map[string]*indexedFile) {
 	s.mu.Lock()
+	// Drop id contributions from the previous indexed-only set, keeping those
+	// from currently-open docs (which are re-added below if also indexed).
+	for uri := range s.indexed {
+		if _, open := s.docs[uri]; !open {
+			delete(s.ruleIDs, uri)
+		}
+	}
 	if idx == nil {
 		s.indexed = make(map[string]*indexedFile)
 	} else {
 		s.indexed = idx
 	}
+	for uri, f := range s.indexed {
+		// Open docs win over the on-disk snapshot for the same URI.
+		if _, open := s.docs[uri]; open {
+			continue
+		}
+		s.setRuleIDs(uri, f.AST)
+	}
+	s.xfGen++ // ensure the cache rebuilds even if no per-file set changed
 	s.mu.Unlock()
 }
 
@@ -72,9 +186,11 @@ func (s *DocumentStore) Open(uri, content string, version int32) *Document {
 		Version: version,
 		Content: content,
 		AST:     parser.Parse(uri, content),
+		Lines:   splitLines(content),
 	}
 	s.mu.Lock()
 	s.docs[uri] = doc
+	s.setRuleIDs(uri, doc.AST)
 	s.mu.Unlock()
 	return doc
 }
@@ -89,6 +205,13 @@ func (s *DocumentStore) Change(uri, content string, version int32) *Document {
 func (s *DocumentStore) Close(uri string) {
 	s.mu.Lock()
 	delete(s.docs, uri)
+	// If the file is still in the indexed (on-disk) set, fall back to that
+	// snapshot's id contribution; otherwise drop it entirely.
+	if f, ok := s.indexed[uri]; ok {
+		s.setRuleIDs(uri, f.AST)
+	} else {
+		s.setRuleIDs(uri, nil)
+	}
 	s.mu.Unlock()
 }
 

--- a/pkg/lsp/documents_test.go
+++ b/pkg/lsp/documents_test.go
@@ -5,10 +5,13 @@
 package lsp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/parser"
 )
 
 func TestDocumentStore_OpenAndGet(t *testing.T) {
@@ -100,19 +103,37 @@ func TestDocumentStore_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	s := NewDocumentStore()
 	const n = 50
-	done := make(chan struct{}, n*2)
+	// Mix every mutating and reading entry point on overlapping URIs so the
+	// race detector exercises the read-copy-out contract on AllDocs/All/AllASTs
+	// and the cross-file id cache (SetIndex/CrossFileIDs) interleaved with
+	// Open/Change/Close.
+	const workers = 9
+	done := make(chan struct{}, n*workers)
+	src := `SecRule ARGS "@rx x" "id:%d,phase:2,deny"`
 
 	for i := 0; i < n; i++ {
+		i := i
+		go func() { s.Open("file:///a.conf", "SecRuleEngine On", int32(i)); done <- struct{}{} }()
 		go func() {
-			s.Open("file:///a.conf", "SecRuleEngine On", 1)
+			s.Change("file:///b.conf", "SecRule ARGS \"@rx y\" \"id:42,phase:2,deny\"", int32(i))
 			done <- struct{}{}
 		}()
+		go func() { s.Close("file:///a.conf"); done <- struct{}{} }()
+		go func() { s.Get("file:///a.conf"); done <- struct{}{} }()
+		go func() { _ = s.AllDocs(); done <- struct{}{} }()
+		go func() { _ = s.All(); done <- struct{}{} }()
+		go func() { _ = s.AllASTs(); done <- struct{}{} }()
+		go func() { _ = s.CrossFileIDs(); done <- struct{}{} }()
 		go func() {
-			s.Get("file:///a.conf")
+			f := parser.Parse("file:///idx.conf", fmt.Sprintf(src, 42))
+			s.SetIndex(map[string]*indexedFile{
+				"file:///idx.conf": {Path: "/idx.conf", AST: f},
+				"file:///b.conf":   {Path: "/b.conf", AST: f},
+			})
 			done <- struct{}{}
 		}()
 	}
-	for i := 0; i < n*2; i++ {
+	for i := 0; i < n*workers; i++ {
 		<-done
 	}
 }

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -5,8 +5,9 @@
 package lsp
 
 import (
-	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -101,21 +102,82 @@ func New(version string, opts ...Option) *Server {
 	return s
 }
 
+// maxWSMessageBytes bounds the size of a single inbound WebSocket message so a
+// hostile client can't force an unbounded allocation. Generous enough for very
+// large rule files, bounded enough to deny a memory-exhaustion DoS.
+//
+// NOTE: this cap only applies to the WebSocket transport, where gorilla exposes
+// Conn.SetReadLimit. The TCP transport goes through glsp's hardcoded
+// jsonrpc2.VSCodeObjectCodec, which reads a client-supplied Content-Length and
+// allocates that many bytes with no upstream hook to bound it; we do not fork
+// glsp. The mitigation there is to bind TCP/WS to loopback only (see
+// cmd/coraza-lsp). Both transports are documented as loopback-dev-only.
+const maxWSMessageBytes = 32 << 20 // 32 MiB
+
 // RunStdio starts the LSP server over stdin/stdout.
 func (s *Server) RunStdio() error { return s.glsp.RunStdio() }
 
 // RunTCP starts the LSP server on the given TCP address (e.g. "127.0.0.1:7998").
+//
+// SECURITY: there is no per-message size limit on this transport — glsp's
+// jsonrpc2 codec honours a client-supplied Content-Length with no upstream
+// hook to bound it (see maxWSMessageBytes). Bind to loopback only and treat
+// this transport as dev-only.
 func (s *Server) RunTCP(addr string) error { return s.glsp.RunTCP(addr) }
 
-// RunWebSocket starts the LSP server on the given WebSocket address. It binds
-// its own listener and upgrades incoming HTTP requests. Embedders that already
-// own an HTTP router (and want to authenticate the upgrade themselves) should
+// RunWebSocket starts the LSP server on the given WebSocket address. Unlike the
+// bundled glsp entrypoint (which accepts any Origin and sets no read limit),
+// this owns the HTTP upgrade so it can:
+//   - enforce a strict same-origin / no-Origin policy (rejecting cross-origin
+//     browser connections), and
+//   - cap the inbound message size via Conn.SetReadLimit.
+//
+// Native editor clients send no Origin header and are accepted; browser pages
+// send one and are rejected unless it matches the listen host. Embedders that
+// already own an HTTP router (and authenticate the upgrade themselves) should
 // upgrade in their own handler and call ServeWebSocket on the resulting
 // *websocket.Conn instead.
-func (s *Server) RunWebSocket(addr string) error { return s.glsp.RunWebSocket(addr) }
+func (s *Server) RunWebSocket(addr string) error {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return checkWSOrigin(r) },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("coraza-lsp: websocket upgrade failed: %v", err)
+			return
+		}
+		defer conn.Close()
+		s.ServeWebSocket(conn)
+	})
+	server := &http.Server{Addr: addr, Handler: mux}
+	log.Printf("coraza-lsp: listening for WebSocket connections on %s", addr)
+	return server.ListenAndServe()
+}
+
+// checkWSOrigin rejects cross-origin browser connections. Requests with no
+// Origin header (native editors, CLI tools) are allowed. Requests whose Origin
+// host doesn't match the request Host are rejected. This is intentionally
+// strict: the WS transport is loopback-dev-only and must not be drivable from
+// an arbitrary web page (which could otherwise reach the file-read primitive
+// in the analyser).
+func checkWSOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true // non-browser client
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	// Allow only when the Origin host matches the host we're serving on.
+	return strings.EqualFold(u.Host, r.Host)
+}
 
 // ServeWebSocket drives the LSP protocol over an already-upgraded WebSocket
-// connection. It blocks until the client disconnects. Use this from an
+// connection. It applies a read limit (maxWSMessageBytes) to bound inbound
+// allocations, then blocks until the client disconnects. Use this from an
 // authenticated HTTP handler:
 //
 //	upgrader := websocket.Upgrader{...}
@@ -123,7 +185,10 @@ func (s *Server) RunWebSocket(addr string) error { return s.glsp.RunWebSocket(ad
 //	if err != nil { return }
 //	defer conn.Close()
 //	lspsrv.ServeWebSocket(conn)
-func (s *Server) ServeWebSocket(conn *websocket.Conn) { s.glsp.ServeWebSocket(conn) }
+func (s *Server) ServeWebSocket(conn *websocket.Conn) {
+	conn.SetReadLimit(maxWSMessageBytes)
+	s.glsp.ServeWebSocket(conn)
+}
 
 // saveCtx stores the most-recent glsp.Context for async notifications.
 func (s *Server) saveCtx(ctx *glsp.Context) {
@@ -264,8 +329,14 @@ func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocu
 	if len(params.ContentChanges) == 0 {
 		return nil
 	}
-	// Full-sync: the last event always carries the entire document text.
-	text := extractFullText(params.ContentChanges[len(params.ContentChanges)-1])
+	// Full-sync: the last event always carries the entire document text. If
+	// the client misbehaves and sends an incremental change (or a value we
+	// can't interpret), skip the update rather than overwriting the document
+	// with a fragment or an empty string.
+	text, ok := extractFullText(params.ContentChanges[len(params.ContentChanges)-1])
+	if !ok {
+		return nil
+	}
 	uri := string(params.TextDocument.URI)
 	doc := s.store.Change(uri, text, params.TextDocument.Version)
 	s.pushDiagnostics(ctx, uri, doc)
@@ -311,7 +382,7 @@ func (s *Server) completionHandler(ctx *glsp.Context, params *protocol.Completio
 	line := int(params.Position.Line)
 	char := int(params.Position.Character)
 
-	lines := splitLines(doc.Content)
+	lines := doc.Lines
 	if line >= len(lines) {
 		return nil, nil
 	}
@@ -430,16 +501,34 @@ func splitLines(s string) []string {
 	return lines
 }
 
-// extractFullText extracts the text from a TextDocumentContentChangeEvent.
-// Under full-sync, every event is a "whole" event with only a Text field.
-func extractFullText(raw any) string {
-	b, err := json.Marshal(raw)
-	if err != nil {
-		return ""
+// extractFullText extracts the whole-document text from a content-change
+// event. The server advertises TextDocumentSyncKindFull, so glsp has already
+// unmarshalled each change into a concrete typed value (see
+// DidChangeTextDocumentParams.UnmarshalJSON): a "whole" event when no Range is
+// present, otherwise an incremental event with a Range.
+//
+// A direct type switch avoids the JSON marshal/unmarshal round-trip that used
+// to run on every keystroke. The second return is false when the change cannot
+// be treated as a full-document replacement (a mis-typed value, or an
+// incremental change carrying a Range) so the caller can skip the store update
+// rather than clobbering the document with a fragment or an empty string.
+func extractFullText(raw any) (string, bool) {
+	switch v := raw.(type) {
+	case protocol.TextDocumentContentChangeEventWhole:
+		return v.Text, true
+	case *protocol.TextDocumentContentChangeEventWhole:
+		return v.Text, true
+	case protocol.TextDocumentContentChangeEvent:
+		// Only a full replacement when no Range is present.
+		if v.Range == nil {
+			return v.Text, true
+		}
+		return "", false
+	case *protocol.TextDocumentContentChangeEvent:
+		if v.Range == nil {
+			return v.Text, true
+		}
+		return "", false
 	}
-	var whole protocol.TextDocumentContentChangeEventWhole
-	if err := json.Unmarshal(b, &whole); err != nil {
-		return ""
-	}
-	return whole.Text
+	return "", false
 }

--- a/pkg/lsp/handler_test.go
+++ b/pkg/lsp/handler_test.go
@@ -6,6 +6,7 @@ package lsp
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,16 +54,14 @@ func TestDidChange_UpdatesContent(t *testing.T) {
 	openDoc(t, s, "file:///test.conf", "SecRuleEngine On")
 
 	ctx := newTestCtx()
-	raw, _ := json.Marshal(protocol.TextDocumentContentChangeEventWhole{Text: "SecRuleEngine Off"})
-	var change any
-	json.Unmarshal(raw, &change)
-	err := s.didChange(ctx, &protocol.DidChangeTextDocumentParams{
-		TextDocument: protocol.VersionedTextDocumentIdentifier{
-			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: "file:///test.conf"},
-			Version:                2,
-		},
-		ContentChanges: []interface{}{change},
-	})
+	// Build params via the same JSON path glsp uses on the wire, so
+	// ContentChanges holds the concrete typed value (a whole-document event)
+	// that didChange/extractFullText expect — not a generic map.
+	var params protocol.DidChangeTextDocumentParams
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"textDocument":{"uri":"file:///test.conf","version":2},`+
+			`"contentChanges":[{"text":"SecRuleEngine Off"}]}`), &params))
+	err := s.didChange(ctx, &params)
 	require.NoError(t, err)
 	doc := s.store.Get("file:///test.conf")
 	require.NotNil(t, doc)
@@ -312,4 +311,45 @@ func TestSplitLines(t *testing.T) {
 		got := splitLines(tc.input)
 		assert.Equal(t, tc.expected, got, "input: %q", tc.input)
 	}
+}
+
+func TestExtractFullText(t *testing.T) {
+	t.Parallel()
+	rng := &protocol.Range{}
+	cases := []struct {
+		name   string
+		raw    any
+		want   string
+		wantOK bool
+	}{
+		{"whole value", protocol.TextDocumentContentChangeEventWhole{Text: "hello"}, "hello", true},
+		{"whole pointer", &protocol.TextDocumentContentChangeEventWhole{Text: "hi"}, "hi", true},
+		{"full event no range", protocol.TextDocumentContentChangeEvent{Text: "full"}, "full", true},
+		{"full event ptr no range", &protocol.TextDocumentContentChangeEvent{Text: "fp"}, "fp", true},
+		{"incremental event rejected", protocol.TextDocumentContentChangeEvent{Range: rng, Text: "frag"}, "", false},
+		{"incremental ptr rejected", &protocol.TextDocumentContentChangeEvent{Range: rng, Text: "frag"}, "", false},
+		{"mistyped value rejected", 42, "", false},
+		{"nil rejected", nil, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractFullText(tc.raw)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCheckWSOrigin(t *testing.T) {
+	t.Parallel()
+	mk := func(origin, host string) *http.Request {
+		r := &http.Request{Header: http.Header{}, Host: host}
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		return r
+	}
+	assert.True(t, checkWSOrigin(mk("", "127.0.0.1:7999")), "no Origin (native client) allowed")
+	assert.True(t, checkWSOrigin(mk("http://127.0.0.1:7999", "127.0.0.1:7999")), "same-origin allowed")
+	assert.False(t, checkWSOrigin(mk("http://evil.example", "127.0.0.1:7999")), "cross-origin rejected")
 }

--- a/pkg/lsp/workspace.go
+++ b/pkg/lsp/workspace.go
@@ -6,12 +6,22 @@ package lsp
 
 import (
 	"io/fs"
+	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
 	"github.com/coraza-incubator/coraza-lsp/internal/vfs"
 )
+
+// maxIndexedFileSize caps how many bytes a single workspace file may have
+// before indexWorkspace skips it. Global indexing happens automatically (the
+// user never opened the file), so a stray multi-hundred-MB file must not be
+// slurped into memory and parsed. Files above this size are skipped with a log
+// note.
+const maxIndexedFileSize = 4 << 20 // 4 MiB
 
 // indexedFile is a parsed rule file that the user did not open in the editor.
 // Only populated when config.Global is true. Unlike Document, it holds just
@@ -50,6 +60,12 @@ func indexWorkspace(filesys vfs.FileSystem, root string, filePatterns, ignore []
 		if matchesAny(path, ignore, root) {
 			return nil
 		}
+		// Skip pathologically large files: global indexing is automatic, so a
+		// stray huge .conf must not be read whole into memory and parsed.
+		if info, ierr := d.Info(); ierr == nil && info.Size() > maxIndexedFileSize {
+			log.Printf("coraza-lsp: skipping %s from workspace index (%d bytes > %d)", path, info.Size(), maxIndexedFileSize)
+			return nil
+		}
 		if !sniffsAsSecLang(filesys, path) {
 			return nil
 		}
@@ -68,9 +84,17 @@ func indexWorkspace(filesys vfs.FileSystem, root string, filePatterns, ignore []
 }
 
 // matchesAny reports whether path matches any of the given globs, relative to
-// root. Uses filepath.Match — supports `*` and `?` but not `**`. `**/*.conf`
-// is normalised to `*.conf` applied at every depth (the walk visits every
-// path so this is equivalent).
+// root. Globs use doublestar semantics (github.com/bmatcuk/doublestar): `*`
+// and `?` within a path segment, `**` to match across path separators, and
+// `{a,b}` brace alternation — matching the behaviour documented for
+// `filePatterns`/`ignore` in internal/config. Matching is always performed on
+// the slash-separated path relative to root so patterns like `**/*.conf` and
+// `**/deprecated/**` work regardless of OS.
+//
+// Patterns are matched against both the relative path and the base name, so a
+// bare `*.conf` (no leading `**/`) still matches a nested file as the docs
+// imply. Malformed patterns are skipped (they cannot match) rather than
+// silently aborting the whole walk.
 func matchesAny(path string, globs []string, root string) bool {
 	if len(globs) == 0 {
 		return false
@@ -80,21 +104,21 @@ func matchesAny(path string, globs []string, root string) bool {
 		rel = path
 	}
 	rel = filepath.ToSlash(rel)
-	base := filepath.Base(path)
+	base := filepath.ToSlash(filepath.Base(path))
 	for _, glob := range globs {
 		g := filepath.ToSlash(glob)
-		// Strip a leading "**/" so the pattern matches at any depth.
-		flat := strings.TrimPrefix(g, "**/")
-		if ok, _ := filepath.Match(flat, base); ok {
+		if !doublestar.ValidatePattern(g) {
+			// Malformed glob: cannot match anything; ignore it so one bad
+			// entry can't short-circuit indexing.
+			continue
+		}
+		if ok, _ := doublestar.Match(g, rel); ok {
 			return true
 		}
-		if ok, _ := filepath.Match(g, rel); ok {
-			return true
-		}
-		// "**/deprecated/**" on directory paths.
-		if strings.Contains(g, "/**") {
-			prefix := strings.TrimSuffix(strings.TrimPrefix(g, "**/"), "/**")
-			if prefix != "" && strings.Contains("/"+rel+"/", "/"+prefix+"/") {
+		// A pattern without a `**`/`/` prefix (e.g. "*.conf") is conventionally
+		// understood to apply at any depth; match it against the base name too.
+		if !strings.Contains(g, "/") {
+			if ok, _ := doublestar.Match(g, base); ok {
 				return true
 			}
 		}

--- a/pkg/lsp/workspace_test.go
+++ b/pkg/lsp/workspace_test.go
@@ -75,6 +75,48 @@ func TestIndexWorkspace_RespectsIgnore(t *testing.T) {
 	}
 }
 
+// --- matchesAny (doublestar glob semantics) ---------------------------------
+
+func TestMatchesAny_Doublestar(t *testing.T) {
+	t.Parallel()
+	root := "/ws"
+	cases := []struct {
+		name  string
+		path  string
+		globs []string
+		want  bool
+	}{
+		{"doublestar matches nested", "/ws/a/b/c.conf", []string{"**/*.conf"}, true},
+		{"doublestar matches top-level", "/ws/c.conf", []string{"**/*.conf"}, true},
+		{"non-matching extension", "/ws/a/b/c.txt", []string{"**/*.conf"}, false},
+		{"bare basename glob matches at depth", "/ws/a/b/c.conf", []string{"*.conf"}, true},
+		{"brace alternation", "/ws/a/x.modsec", []string{"**/*.{conf,modsec}"}, true},
+		{"multi doublestar", "/ws/a/b/c/d.conf", []string{"**/**/*.conf"}, true},
+		{"anchored subdir does not match other depth", "/ws/a/rules/foo.conf", []string{"rules/*.conf"}, false},
+		{"anchored subdir matches at root", "/ws/rules/foo.conf", []string{"rules/*.conf"}, true},
+		{"ignore deprecated tree", "/ws/x/deprecated/old.conf", []string{"**/deprecated/**"}, true},
+		{"ignore git tree", "/ws/.git/hidden.conf", []string{"**/.git/**"}, true},
+		{"malformed glob is skipped", "/ws/a.conf", []string{"[", "**/*.conf"}, true},
+		{"empty globs", "/ws/a.conf", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesAny(filepath.FromSlash(tc.path), tc.globs, filepath.FromSlash(root))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIndexWorkspace_NestedDoublestar(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a", "b", "c.conf"),
+		`SecRule ARGS "@rx x" "id:1,phase:2,deny"`)
+
+	idx := indexWorkspace(testFS, root, []string{"**/*.conf"}, nil)
+	assert.Len(t, idx, 1, "**/*.conf must match a deeply nested file")
+}
+
 func TestIndexWorkspace_EmptyRoot(t *testing.T) {
 	t.Parallel()
 	idx := indexWorkspace(testFS, "", []string{"**/*.conf"}, nil)


### PR DESCRIPTION
Verified audit fixes in the LSP server layer (`pkg/lsp` + `cmd/coraza-lsp` transports). Full suite green under `-race`; vet/build clean. (Three overlapping findings — closed-doc race, Include file-read, Stage-2 size cap — were already fixed in #5 and are not redone here.)

- **HIGH — config lock no longer held during workspace indexing.** A `global` workspace scan (walk + read + parse every file) ran while holding the `cfgState` write lock, blocking every concurrent request. Config state is now installed under a short lock; the index is built and swapped in outside it.
- **Data race on `cfgState.root`** — `watchLoop` read it unlocked. Now via a locked accessor (verified `-race`).
- **Doublestar globs** — `filePatterns`/`ignore` used `filepath.Match`, so the documented `**/*.conf` didn't match nested paths. Now `bmatcuk/doublestar/v4`; malformed globs skipped.
- **No more JSON round-trip per keystroke** — `extractFullText` type-switches instead of marshal+unmarshal; an incremental/mistyped change no longer clobbers the document.
- **Transport hardening** — WebSocket Origin check + 32 MiB read limit; `--tcp/--ws` default a wildcard bind to loopback. (glsp exposes no TCP per-message cap; documented.)
- **Efficiency** — cross-file id index cached/incremental instead of rebuilt every request; `Document.Lines` cached at parse.
- **Tests** — DocumentStore concurrency test extended across the mutating API under `-race`.

New dep: `github.com/bmatcuk/doublestar/v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)