### PR TITLE
fix(knowledge): reconcile KB with Coraza v3.5.0 + add drift guard

### DIFF
--- a/internal/analysis/diagnostics_test.go
+++ b/internal/analysis/diagnostics_test.go
@@ -1957,8 +1957,22 @@ func TestAnalyze_CtlValidation(t *testing.T) {
 			wantCodes: nil,
 		},
 		{
-			name:      "valid ctl noAuditLog (no value)",
+			// Coraza v3.5.0 does NOT register a `noAuditLog` ctl sub-option; the
+			// ctl action's switch rejects it as `unknown ctl action "noAuditLog"`.
+			// It was removed from the KB CtlOptions, so the LSP must flag it.
+			name:      "unknown ctl noAuditLog (not a Coraza ctl option)",
 			src:       `SecAction "id:1,phase:1,pass,ctl:noAuditLog"`,
+			wantCodes: []string{CodeUnknownCtlOption},
+		},
+		{
+			// New in this KB revision — used by real CRS rules.
+			name:      "valid ctl ruleRemoveByMsg (free-form value)",
+			src:       `SecAction "id:1,phase:1,pass,ctl:ruleRemoveByMsg=SQLi"`,
+			wantCodes: nil,
+		},
+		{
+			name:      "valid ctl ruleRemoveTargetByMsg (free-form value)",
+			src:       `SecAction "id:1,phase:1,pass,ctl:ruleRemoveTargetByMsg=SQLi;ARGS:x"`,
 			wantCodes: nil,
 		},
 		{

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -443,7 +443,12 @@ func TestGetCompletions_CtlKey_Empty(t *testing.T) {
 	labels := itemLabels(items)
 	assert.Contains(t, labels, "ruleEngine")
 	assert.Contains(t, labels, "requestBodyProcessor")
-	assert.Contains(t, labels, "noAuditLog")
+	// ruleRemoveByMsg / ruleRemoveTargetByMsg are real Coraza v3.5.0 ctl
+	// sub-options used by CRS; they must be offered for completion.
+	assert.Contains(t, labels, "ruleRemoveByMsg")
+	assert.Contains(t, labels, "ruleRemoveTargetByMsg")
+	// `noAuditLog` is NOT a Coraza ctl sub-option and must NOT be offered.
+	assert.NotContains(t, labels, "noAuditLog")
 }
 
 func TestGetCompletions_CtlKey_Prefix(t *testing.T) {
@@ -472,16 +477,17 @@ func TestGetCompletions_CtlKey_InsertTextHasEquals(t *testing.T) {
 
 func TestGetCompletions_CtlKey_NoValueOptionHasNoEquals(t *testing.T) {
 	t.Parallel()
-	// noAuditLog takes no value — insert text must NOT include =.
-	items := GetCompletions(ContextCtlKey, "noAudit")
+	// Coraza v3.5.0 has no value-less ctl sub-options (the former `noAuditLog`
+	// entry was removed because Coraza does not register it). This test now
+	// guards the inverse invariant: every offered ctl key that is NOT a
+	// NoValue option must insert "KEY=" so the cursor lands after the '='.
+	items := GetCompletions(ContextCtlKey, "")
+	require.NotEmpty(t, items)
 	for _, item := range items {
-		if item.Label == "noAuditLog" {
-			require.NotNil(t, item.InsertText)
-			assert.Equal(t, "noAuditLog", *item.InsertText)
-			return
-		}
+		require.NotNil(t, item.InsertText, "ctl key %q must have InsertText", item.Label)
+		assert.Equal(t, item.Label+"=", *item.InsertText,
+			"value-taking ctl key %q should insert %q=", item.Label, item.Label)
 	}
-	t.Fatal("noAuditLog not found in ctl key completions")
 }
 
 func TestGetCompletions_CtlValue_RuleEngine(t *testing.T) {

--- a/internal/knowledge/actions.go
+++ b/internal/knowledge/actions.go
@@ -64,28 +64,11 @@ var allActions = []Item{
 		Description: "**redirect** stops rule processing and issues an HTTP redirect (default 302)\n" +
 			"to the specified URL. Use `status:301` for permanent redirects.",
 	},
-	{
-		Name:        "proxy",
-		ActionType:  "disruptive",
-		Summary:     "Forward the request to another backend server (ModSecurity 2.x only)",
-		Syntax:      "proxy:URL",
-		Example:     `SecRule REQUEST_URI "@rx /api" "id:7,phase:1,proxy:http://api-server:8080"`,
-		Description: "**proxy** forwards the request transparently to a different backend server.\n" +
-			"The original client is unaware of the forwarding.\n\n" +
-			"**Note:** This action is defined in ModSecurity 2.x but is not implemented in Coraza v3. " +
-			"It will be parsed but may have no effect.",
-	},
-	{
-		Name:        "pause",
-		ActionType:  "disruptive",
-		Summary:     "Pause transaction processing for a number of milliseconds (ModSecurity 2.x only)",
-		Syntax:      "pause:MILLISECONDS",
-		Example:     `SecRule TX:ratelimit "@gt 10" "id:8,phase:1,pause:500"`,
-		Description: "**pause** introduces a delay in processing the current transaction.\n" +
-			"Useful for rate limiting and tarpit functionality.\n\n" +
-			"**Note:** This action is defined in ModSecurity 2.x but is not implemented in Coraza v3. " +
-			"It will be parsed but may have no effect.",
-	},
+	// Note: ModSecurity 2.x `proxy` and `pause` actions are intentionally NOT
+	// listed here. Coraza v3.5.0 does not register them and rejects them at
+	// parse time with `invalid action "proxy"` / `invalid action "pause"`
+	// (internal/actions/actions.go Get + appendRuleAction return the error).
+	// Listing them would suppress a correct unknown-action diagnostic.
 	// Metadata actions
 	{
 		Name:        "id",
@@ -165,14 +148,12 @@ var allActions = []Item{
 		Example:     "maturity:9",
 		Description: "**maturity** rates how well-tested the rule is: 1 (experimental) to 9 (production-ready).",
 	},
-	{
-		Name:        "accuracy",
-		ActionType:  "metadata",
-		Summary:     "Rule accuracy/false-positive rate (1–9)",
-		Syntax:      "accuracy:NUMBER",
-		Example:     "accuracy:8",
-		Description: "**accuracy** rates how likely the rule is to produce false positives: 1 (high FP rate) to 9 (very accurate).",
-	},
+	// Note: ModSecurity's `accuracy` metadata action is intentionally NOT listed
+	// here. Coraza v3.5.0 does not register it (it appears only inside a comment
+	// in internal/actions/maturity.go) and rejects it at parse time with
+	// `invalid action "accuracy"`. Modern OWASP CRS v4 no longer emits `accuracy`,
+	// so dropping it does not introduce false positives on CRS.
+	// `maturity`, `rev`, and `ver` ARE registered by Coraza and are kept above.
 	// Non-disruptive actions
 	{
 		Name:        "log",
@@ -307,7 +288,8 @@ var allActions = []Item{
 		Description: "**skipAfter** jumps execution to the first rule after the named `SecMarker` when\n" +
 			"this rule matches. The marker must appear later in the same configuration.",
 	},
-	// Data actions
+	// Data actions (status is the only Coraza ActionTypeData action;
+	// `t` and `ctl` below are ActionTypeNondisruptive in Coraza v3.5.0)
 	{
 		Name:        "status",
 		ActionType:  "data",
@@ -319,7 +301,7 @@ var allActions = []Item{
 	},
 	{
 		Name:        "t",
-		ActionType:  "data",
+		ActionType:  "non-disruptive",
 		Summary:     "Apply a transformation function before matching",
 		Syntax:      "t:TRANSFORMATION",
 		Example:     "t:lowercase,t:urlDecode",
@@ -329,7 +311,7 @@ var allActions = []Item{
 	},
 	{
 		Name:        "ctl",
-		ActionType:  "data",
+		ActionType:  "non-disruptive",
 		Summary:     "Change a WAF configuration option for this transaction",
 		Syntax:      "ctl:OPTION=VALUE",
 		Example:     "ctl:requestBodyProcessor=JSON",

--- a/internal/knowledge/ctl.go
+++ b/internal/knowledge/ctl.go
@@ -11,10 +11,17 @@ type CtlOption struct {
 	Key     string
 	Summary string
 	Values  []string // valid enum values; nil = free-form input accepted
-	NoValue bool     // true for options that take no = and no value (e.g. noAuditLog)
+	NoValue bool     // true for options that take no = and no value
 }
 
 // CtlOptions lists all recognised ctl sub-options in canonical casing.
+//
+// This set is the authoritative one accepted by Coraza v3.5.0's ctl action,
+// taken from the string switch in internal/actions/ctl.go (Init: the `switch
+// action` block, ~lines 433-475). Any name outside this set makes Coraza fail
+// with `unknown ctl action %q`, so adding speculative options here would
+// suppress a correct unknown-ctl-option diagnostic. Note: ModSecurity's
+// `ctl:noAuditLog` is intentionally absent — Coraza does NOT register it.
 var CtlOptions = []CtlOption{
 	{
 		Key:     "ruleEngine",
@@ -26,16 +33,33 @@ var CtlOptions = []CtlOption{
 		Summary: "Remove a rule (or ID range) for this transaction, e.g. 1001 or 1000-1999",
 	},
 	{
+		Key:     "ruleRemoveByMsg",
+		Summary: "Remove all rules whose msg matches the given value for this transaction",
+	},
+	{
 		Key:     "ruleRemoveByTag",
 		Summary: "Remove all rules with the given tag for this transaction",
 	},
 	{
 		Key:     "ruleRemoveTargetById",
-		Summary: "Remove a specific inspection target from a rule by ID (format: id/VARIABLE[/key])",
+		Summary: "Remove a specific inspection target from a rule by ID (format: id;VARIABLE)",
+	},
+	{
+		Key:     "ruleRemoveTargetByMsg",
+		Summary: "Remove a specific inspection target from rules matching a msg (format: msg;VARIABLE)",
 	},
 	{
 		Key:     "ruleRemoveTargetByTag",
-		Summary: "Remove a specific inspection target from all rules with a tag (format: tag/VARIABLE[/key])",
+		Summary: "Remove a specific inspection target from all rules with a tag (format: tag;VARIABLE)",
+	},
+	{
+		Key:     "auditEngine",
+		Summary: "Override the audit engine setting for this transaction",
+		Values:  []string{"On", "Off", "RelevantOnly"},
+	},
+	{
+		Key:     "auditLogParts",
+		Summary: "Override which audit log parts are recorded for this transaction (e.g. +E)",
 	},
 	{
 		Key:     "requestBodyAccess",
@@ -66,14 +90,24 @@ var CtlOptions = []CtlOption{
 		Summary: "Maximum response body size in bytes for this transaction",
 	},
 	{
-		Key:     "auditEngine",
-		Summary: "Override the audit engine setting for this transaction",
-		Values:  []string{"On", "Off", "RelevantOnly"},
+		Key:     "responseBodyProcessor",
+		Summary: "Force a specific response body parser for this transaction",
+		Values:  []string{"URLENCODED", "MULTIPART", "XML", "JSON"},
 	},
 	{
-		Key:     "noAuditLog",
-		Summary: "Suppress the audit log entry for this transaction (no value required)",
-		NoValue: true,
+		Key:     "forceResponseBodyVariable",
+		Summary: "Force population of RESPONSE_BODY even without a recognised Content-Type",
+		Values:  []string{"On", "Off"},
+	},
+	{
+		Key:     "hashEngine",
+		Summary: "Enable or disable the hash engine for this transaction",
+		Values:  []string{"On", "Off"},
+	},
+	{
+		Key:     "hashEnforcement",
+		Summary: "Enable or disable hash enforcement for this transaction",
+		Values:  []string{"On", "Off"},
 	},
 	{
 		Key:     "debugLogLevel",

--- a/internal/knowledge/directives.go
+++ b/internal/knowledge/directives.go
@@ -307,10 +307,16 @@ var allDirectives = []Item{
 	},
 	{
 		Name:    "SecRuleUpdateTargetByMsg",
-		Summary: "Add variables to rules matching a msg regex",
+		Summary: "Add variables to rules matching a msg regex (no-op in Coraza)",
 		Syntax:  `SecRuleUpdateTargetByMsg REGEX "VARIABLES"`,
 		Example: `SecRuleUpdateTargetByMsg "SQL Injection" "!ARGS:id"`,
-		Description: "**SecRuleUpdateTargetByMsg** appends variables to all rules whose `msg` matches the given regex.",
+		Description: "**SecRuleUpdateTargetByMsg** is intended to append variables to all rules whose `msg`\n" +
+			"matches the given regex.\n\n" +
+			"**Note:** Coraza v3.5.0 maps this directive to `directiveUnsupported` " +
+			"(internal/seclang/directivesmap.gen.go) — it is accepted at parse time but does nothing. " +
+			"Unlike `SecRuleUpdateTargetById` and `SecRuleUpdateTargetByTag`, which are fully functional, " +
+			"target exclusions written with this directive will silently have no effect.",
+		Deprecated: true,
 	},
 	{
 		Name:    "SecRuleUpdateTargetByTag",
@@ -575,5 +581,79 @@ var allDirectives = []Item{
 		Example: `SecAuditLogFileMode 0640`,
 		Description: "**SecAuditLogFileMode** sets the Unix permission mode for individual audit log\n" +
 			"files created under `SecAuditLogStorageDir`. Default is 0600.",
+	},
+	// Accepted-but-ignored directives.
+	//
+	// Coraza v3.5.0 registers the following directive names in
+	// internal/seclang/directivesmap.gen.go but maps each to
+	// `directiveUnsupported`, which `return nil`s without doing anything. They
+	// are listed here (rather than omitted) so the LSP does NOT emit a spurious
+	// "unknown directive" diagnostic for configs ported from ModSecurity — while
+	// the descriptions and Deprecated flag make clear they have no effect in
+	// Coraza. (Note: ModSecurity's SecRxPreFilter is NOT in Coraza v3.5.0's map
+	// and is intentionally not listed.)
+	{
+		Name:    "SecArgumentSeparator",
+		Summary: "Set the argument separator for application/x-www-form-urlencoded data (no-op in Coraza)",
+		Syntax:  `SecArgumentSeparator CHAR`,
+		Example: `SecArgumentSeparator &`,
+		Description: "**SecArgumentSeparator** defines the character used to separate query-string and\n" +
+			"form arguments (ModSecurity default `&`).\n\n" +
+			"**Note:** Coraza v3.5.0 accepts this directive for compatibility but ignores it " +
+			"(`directiveUnsupported`); the separator is not configurable.",
+		Deprecated: true,
+	},
+	{
+		Name:    "SecCookieFormat",
+		Summary: "Select the cookie parsing format, 0 (Netscape) or 1 (RFC 2965) (no-op in Coraza)",
+		Syntax:  `SecCookieFormat 0|1`,
+		Example: `SecCookieFormat 0`,
+		Description: "**SecCookieFormat** selects how request cookies are parsed in ModSecurity.\n\n" +
+			"**Note:** Coraza v3.5.0 accepts this directive for compatibility but ignores it " +
+			"(`directiveUnsupported`).",
+		Deprecated: true,
+	},
+	{
+		Name:    "SecUnicodeMap",
+		Summary: "Configure the Unicode mapping file and code page (no-op in Coraza)",
+		Syntax:  `SecUnicodeMap FILE [CODEPAGE]`,
+		Example: `SecUnicodeMap unicode.mapping 20127`,
+		Description: "**SecUnicodeMap** specifies the Unicode mapping file used by the `urlDecodeUni`\n" +
+			"and `utf8toUnicode` transformations in ModSecurity.\n\n" +
+			"**Note:** Coraza v3.5.0 accepts this directive for compatibility but ignores it " +
+			"(`directiveUnsupported`).",
+		Deprecated: true,
+	},
+	{
+		Name:    "SecTmpDir",
+		Summary: "Set the directory for temporary files (no-op in Coraza)",
+		Syntax:  `SecTmpDir /path/to/dir`,
+		Example: `SecTmpDir /tmp`,
+		Description: "**SecTmpDir** sets the directory ModSecurity uses for temporary files when data\n" +
+			"must be swapped to disk.\n\n" +
+			"**Note:** Coraza v3.5.0 accepts this directive for compatibility but ignores it " +
+			"(`directiveUnsupported`). Use `SecUploadDir` for uploaded-file storage.",
+		Deprecated: true,
+	},
+	{
+		Name:    "SecRuleScript",
+		Summary: "Define a rule whose logic is implemented by an external script (no-op in Coraza)",
+		Syntax:  `SecRuleScript /path/to/script.lua "ACTIONS"`,
+		Example: `SecRuleScript "/etc/coraza/check.lua" "id:9000,phase:2,deny"`,
+		Description: "**SecRuleScript** runs an external (e.g. Lua) script as a rule in ModSecurity.\n\n" +
+			"**Note:** Coraza v3.5.0 accepts this directive for compatibility but ignores it " +
+			"(`directiveUnsupported`); scripted rules are not executed.",
+		Deprecated: true,
+	},
+	{
+		Name:    "SecRulePerfTime",
+		Summary: "Set a per-rule performance-time logging threshold in microseconds (no-op in Coraza)",
+		Syntax:  `SecRulePerfTime MICROSECONDS`,
+		Example: `SecRulePerfTime 1000`,
+		Description: "**SecRulePerfTime** configures the threshold above which ModSecurity records\n" +
+			"per-rule performance timing.\n\n" +
+			"**Note:** Coraza v3.5.0 accepts this directive for compatibility but ignores it " +
+			"(`directiveUnsupported`).",
+		Deprecated: true,
 	},
 }

--- a/internal/knowledge/drift_test.go
+++ b/internal/knowledge/drift_test.go
@@ -1,0 +1,273 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+
+package knowledge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+)
+
+// drift_test.go is the KNOWLEDGE-BASE DRIFT GUARD.
+//
+// The knowledge base (KB) in this package is the LSP's source of truth for
+// "unknown directive/variable/operator/action/transformation/ctl-option"
+// diagnostics. If the KB lists something the linked OWASP Coraza release does
+// NOT actually register, the LSP silently suppresses a correct diagnostic
+// (false negative). If the KB omits something Coraza DOES register, the LSP
+// emits a spurious diagnostic on valid rules (false positive — e.g. on CRS).
+//
+// This test pins the KB against the ACTUAL Coraza version this module builds
+// against (see go.mod: github.com/corazawaf/coraza/v3). It is fully
+// deterministic and CI-safe: it never touches the network, the filesystem, or
+// any global state — it only compiles tiny SecLang snippets through the public
+// coraza.NewWAF(...WithDirectives()) seam and inspects the parse error.
+//
+// Coraza's registries (actions.actionmap, the operators/transformations
+// registries, the variables name table, the seclang directive map, and the ctl
+// sub-option switch) all live in INTERNAL packages and cannot be imported
+// directly. The public WAF builder is the only reachable seam, so:
+//
+//   - FORWARD guard (fatal): every name the KB lists must be accepted by
+//     Coraza. This is the high-value direction — it catches KB entries that
+//     Coraza rejects (the bug class fixed in this change: accuracy, proxy,
+//     pause, sqlHexDecode, @ne, @containsWord, @verifyCC, @fuzzyHash,
+//     REMOTE_USER, SESSION, ctl:noAuditLog).
+//
+//   - REVERSE guard (non-fatal log): a checked-in ground-truth baseline of the
+//     names Coraza v3.5.0 registers (extracted from the module cache source,
+//     see corazaGroundTruth* below) is compared against the KB. Names Coraza
+//     has that the KB lacks are logged so future Coraza upgrades surface new
+//     capabilities without breaking CI. Accepted-but-ignored (directiveUnsupported)
+//     names are tolerated in both directions.
+//
+// When bumping the Coraza version, re-extract the ground-truth lists from the
+// new module-cache source and update the baselines below.
+
+const corazaPinnedVersion = "v3.5.0"
+
+// probe compiles a single directive and returns the parse error (nil = accepted).
+// Some Coraza operator constructors panic on a malformed argument (e.g.
+// @restpath with a non-template path). A panic means the operator NAME was
+// resolved and registered — only the argument was bad — so it is NOT a
+// name-rejection and we treat it as "accepted" for drift purposes.
+func probe(directive string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = nil
+		}
+	}()
+	_, err = coraza.NewWAF(coraza.NewWAFConfig().WithDirectives(directive))
+	return err
+}
+
+// rejected reports whether err is Coraza's "this name is not registered" class
+// of error for the given element. We match the specific Coraza messages so that
+// unrelated compile errors (bad arg shape, etc.) do not mask a true rejection
+// or cause false failures.
+func rejected(err error, needles ...string) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, n := range needles {
+		if strings.Contains(msg, strings.ToLower(n)) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDriftActions asserts every KB action is registered by Coraza.
+func TestDriftActions(t *testing.T) {
+	for _, it := range allActions {
+		name := it.Name
+		// `t` and `ctl` need a value; the rest parse bare or with a trivial value.
+		var actionToken string
+		switch strings.ToLower(name) {
+		case "t":
+			actionToken = "t:lowercase"
+		case "ctl":
+			actionToken = "ctl:ruleEngine=On"
+		case "skipafter":
+			actionToken = "skipAfter:MARKER"
+		case "skip":
+			actionToken = "skip:1"
+		case "redirect":
+			actionToken = "redirect:http://x"
+		case "status":
+			actionToken = "status:403"
+		case "phase":
+			actionToken = "phase:2"
+		case "severity":
+			actionToken = "severity:2"
+		case "msg":
+			actionToken = "msg:'x'"
+		case "tag":
+			actionToken = "tag:'x'"
+		case "logdata":
+			actionToken = "logdata:'x'"
+		case "rev":
+			actionToken = "rev:1"
+		case "ver":
+			actionToken = "ver:'x'"
+		case "maturity":
+			actionToken = "maturity:1"
+		case "setvar":
+			actionToken = "setvar:TX.x=1"
+		case "setenv":
+			actionToken = "setenv:X=1"
+		case "expirevar":
+			actionToken = "expirevar:TX.x=1"
+		case "initcol":
+			actionToken = "initcol:IP=1"
+		case "exec":
+			actionToken = "exec:/bin/true"
+		default:
+			actionToken = name
+		}
+		dir := `SecRule ARGS "@unconditionalMatch" "id:1,phase:2,` + actionToken + `"`
+		if rejected(probe(dir), `invalid action "`+strings.ToLower(name)+`"`) {
+			t.Errorf("KB action %q is NOT registered by Coraza %s (invalid action) — remove it from allActions or it will suppress a correct unknown-action diagnostic", name, corazaPinnedVersion)
+		}
+	}
+}
+
+// TestDriftTransformations asserts every KB transformation is registered.
+func TestDriftTransformations(t *testing.T) {
+	for _, it := range allTransformations {
+		dir := `SecRule ARGS "@unconditionalMatch" "id:1,phase:2,t:` + it.Name + `"`
+		if rejected(probe(dir), "invalid transformation name") {
+			t.Errorf("KB transformation %q is NOT registered by Coraza %s — remove it from allTransformations", it.Name, corazaPinnedVersion)
+		}
+	}
+}
+
+// TestDriftOperators asserts every KB operator is registered.
+func TestDriftOperators(t *testing.T) {
+	for _, it := range allOperators {
+		// Give every operator a trivial argument so only an unregistered-operator
+		// error (not a missing-arg error) can trip the guard.
+		arg := "x"
+		if strings.EqualFold(it.Name, "restpath") {
+			arg = "/x/{id}" // restpath needs a path template, not a bare token
+		}
+		dir := `SecRule ARGS "@` + it.Name + ` ` + arg + `" "id:1,phase:2,pass"`
+		if rejected(probe(dir), "operator "+strings.ToLower(it.Name)+" not found", "operator "+it.Name+" not found") {
+			t.Errorf("KB operator %q is NOT registered by Coraza %s (operator not found) — remove it from allOperators", it.Name, corazaPinnedVersion)
+		}
+	}
+}
+
+// TestDriftVariables asserts every KB variable is accepted by Coraza's parser.
+func TestDriftVariables(t *testing.T) {
+	for _, it := range allVariables {
+		dir := `SecRule ` + it.Name + ` "@unconditionalMatch" "id:1,phase:2,pass"`
+		if rejected(probe(dir), "unknown variable") {
+			t.Errorf("KB variable %q is NOT recognised by Coraza %s (unknown variable) — remove it from allVariables", it.Name, corazaPinnedVersion)
+		}
+	}
+}
+
+// TestDriftCtlOptions asserts every KB ctl sub-option is accepted by Coraza.
+func TestDriftCtlOptions(t *testing.T) {
+	for _, opt := range CtlOptions {
+		// All current ctl options take a value; "On" is accepted as a generic
+		// payload by the option parser (value validity is checked at runtime).
+		dir := `SecRule ARGS "@unconditionalMatch" "id:1,phase:2,ctl:` + opt.Key + `=On"`
+		if rejected(probe(dir), `unknown ctl action "`+opt.Key+`"`) {
+			t.Errorf("KB ctl option %q is NOT a Coraza %s ctl sub-option (unknown ctl action) — remove it from CtlOptions", opt.Key, corazaPinnedVersion)
+		}
+	}
+}
+
+// --- REVERSE guard: ground-truth baselines (non-fatal) -----------------------
+//
+// These lists are the names Coraza v3.5.0 actually registers, extracted from
+// the module-cache source:
+//   actions:         internal/actions/actions.go      (init() Register calls)
+//   operators:       internal/operators/*.go          (Register("...") calls)
+//   transformations: internal/transformations/*.go    (Register("...") calls)
+//   ctl options:     internal/actions/ctl.go          (the `switch action` block)
+//   variables:       internal/variables/variablesmap.gen.go (rulemapRev keys)
+// Aliases that the KB encodes via Item.Aliases are included so the comparison
+// matches on the full accepted name surface.
+
+var corazaGroundTruthActions = []string{
+	"allow", "auditlog", "block", "capture", "chain", "ctl", "deny", "drop",
+	"exec", "expirevar", "id", "initcol", "log", "logdata", "maturity", "msg",
+	"multimatch", "noauditlog", "nolog", "pass", "phase", "redirect", "rev",
+	"setenv", "setvar", "severity", "skip", "skipafter", "status", "t", "tag", "ver",
+}
+
+var corazaGroundTruthTransformations = []string{
+	"base64decode", "base64decodeext", "base64encode", "cmdline",
+	"compresswhitespace", "cssdecode", "escapeseqdecode", "hexdecode",
+	"hexencode", "htmlentitydecode", "jsdecode", "length", "lowercase", "md5",
+	"none", "normalisepath", "normalisepathwin", "normalizepath",
+	"normalizepathwin", "removecomments", "removecommentschar", "removenulls",
+	"removewhitespace", "replacecomments", "replacenulls", "sha1", "trim",
+	"trimleft", "trimright", "uppercase", "urldecode", "urldecodeuni",
+	"urlencode", "utf8tounicode",
+}
+
+var corazaGroundTruthOperators = []string{
+	"beginswith", "contains", "detectsqli", "detectxss", "endswith", "eq", "ge",
+	"geolookup", "gt", "inspectfile", "ipmatch", "ipmatchf", "ipmatchfromdataset",
+	"ipmatchfromfile", "le", "lt", "nomatch", "pm", "pmf", "pmfromdataset",
+	"pmfromfile", "rbl", "restpath", "rx", "streq", "strmatch",
+	"unconditionalmatch", "validatebyterange", "validatenid", "validateschema",
+	"validateurlencoding", "validateutf8encoding", "within",
+}
+
+var corazaGroundTruthCtlOptions = []string{
+	"auditengine", "auditlogparts", "requestbodyaccess", "requestbodylimit",
+	"requestbodyprocessor", "forcerequestbodyvariable", "responsebodyprocessor",
+	"responsebodyaccess", "responsebodylimit", "forceresponsebodyvariable",
+	"ruleengine", "ruleremovebyid", "ruleremovebymsg", "ruleremovebytag",
+	"ruleremovetargetbyid", "ruleremovetargetbymsg", "ruleremovetargetbytag",
+	"hashengine", "hashenforcement", "debugloglevel",
+}
+
+// reverseCheck logs (non-fatally) any ground-truth name absent from the KB.
+func reverseCheck(t *testing.T, kind string, kbNames map[string]bool, groundTruth []string) {
+	t.Helper()
+	var missing []string
+	for _, n := range groundTruth {
+		if !kbNames[n] {
+			missing = append(missing, n)
+		}
+	}
+	if len(missing) > 0 {
+		t.Logf("REVERSE DRIFT (non-fatal): Coraza %s registers %d %s the KB omits: %v — consider adding for completeness", corazaPinnedVersion, len(missing), kind, missing)
+	}
+}
+
+func kbNameSet(items []Item) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, it := range items {
+		m[strings.ToLower(it.Name)] = true
+		for _, a := range it.Aliases {
+			m[strings.ToLower(a)] = true
+		}
+	}
+	return m
+}
+
+// TestDriftReverseCoverage logs Coraza-registered names the KB does not list.
+// Non-fatal by design: a future Coraza upgrade adding capabilities should
+// surface here without breaking CI, while the forward guards above stay fatal.
+func TestDriftReverseCoverage(t *testing.T) {
+	reverseCheck(t, "actions", kbNameSet(allActions), corazaGroundTruthActions)
+	reverseCheck(t, "transformations", kbNameSet(allTransformations), corazaGroundTruthTransformations)
+	reverseCheck(t, "operators", kbNameSet(allOperators), corazaGroundTruthOperators)
+
+	ctlSet := make(map[string]bool, len(CtlOptions))
+	for _, o := range CtlOptions {
+		ctlSet[strings.ToLower(o.Key)] = true
+	}
+	reverseCheck(t, "ctl options", ctlSet, corazaGroundTruthCtlOptions)
+}

--- a/internal/knowledge/operators.go
+++ b/internal/knowledge/operators.go
@@ -43,14 +43,9 @@ var allOperators = []Item{
 		Description: "**@contains** returns true when the target value contains the specified substring.\n" +
 			"Case-sensitive; use `t:lowercase` for case-insensitive matching.",
 	},
-	{
-		Name:    "containsWord",
-		Summary: "Check if the target contains a word (with word boundary matching)",
-		Syntax:  "@containsWord WORD",
-		Example: `SecRule ARGS "@containsWord select" "id:5,phase:2,deny,t:lowercase"`,
-		Description: "**@containsWord** matches when the target contains the pattern as a complete word\n" +
-			"(surrounded by word boundaries, not adjacent to alphanumeric characters).",
-	},
+	// Note: `@containsWord` is intentionally absent. Coraza v3.5.0 does NOT
+	// register it (internal/operators has no containsWord); Coraza rejects it
+	// at parse time with `operator containsWord not found`.
 	{
 		Name:    "beginsWith",
 		Summary: "Check if the target starts with a string",
@@ -97,13 +92,9 @@ var allOperators = []Item{
 		Description: "**@eq** compares the target as a number and returns true when equal.\n" +
 			"Both target and argument are converted to integers before comparison.",
 	},
-	{
-		Name:    "ne",
-		Summary: "Numeric not-equal comparison",
-		Syntax:  "@ne NUMBER",
-		Example: `SecRule REQBODY_ERROR "@ne 0" "id:12,phase:2,deny"`,
-		Description: "**@ne** returns true when the target numeric value is not equal to the argument.",
-	},
+	// Note: `@ne` is intentionally absent. Coraza v3.5.0 does NOT register a
+	// `ne` operator; it rejects `@ne` at parse time with `operator ne not
+	// found`. Use `!@eq` for a numeric not-equal test.
 	{
 		Name:    "gt",
 		Summary: "Numeric greater-than comparison",
@@ -191,14 +182,9 @@ var allOperators = []Item{
 		Description: "**@validateUtf8Encoding** returns true when the target contains invalid or overlong\n" +
 			"UTF-8 byte sequences.",
 	},
-	{
-		Name:    "verifyCC",
-		Summary: "Detect credit card numbers using Luhn algorithm",
-		Syntax:  "@verifyCC REGEX",
-		Example: `SecRule RESPONSE_BODY "@verifyCC \b(?:4[0-9]{12}(?:[0-9]{3})?)\b" "id:24,phase:4,deny"`,
-		Description: "**@verifyCC** matches the regex against the target and validates any match using the\n" +
-			"Luhn checksum algorithm. Returns true only when a valid credit card number is found.",
-	},
+	// Note: `@verifyCC` is intentionally absent. Coraza v3.5.0 does NOT register
+	// it; it rejects `@verifyCC` at parse time with `operator verifyCC not
+	// found`. (ModSecurity ships verifyCC/verifyCPF/verifySSN; Coraza does not.)
 	{
 		Name:    "noMatch",
 		Summary: "Always returns false (never matches)",
@@ -240,14 +226,9 @@ var allOperators = []Item{
 		Description: "**@inspectFile** executes an external script/program, passing the file path as an\n" +
 			"argument. Returns true when the program returns a non-zero exit code.",
 	},
-	{
-		Name:    "fuzzyHash",
-		Summary: "Match using ssdeep context-triggered piecewise hashing",
-		Syntax:  "@fuzzyHash /path/to/hashes.txt THRESHOLD",
-		Example: `SecRule REQUEST_BODY "@fuzzyHash /etc/coraza/known-malware.txt 75" "id:30,phase:2,deny"`,
-		Description: "**@fuzzyHash** computes an ssdeep fuzzy hash of the target and compares it against\n" +
-			"hashes in a file. The threshold (0–100) controls similarity required.",
-	},
+	// Note: `@fuzzyHash` is intentionally absent. Coraza v3.5.0 does NOT register
+	// it; it rejects `@fuzzyHash` at parse time with `operator fuzzyHash not
+	// found`. (ModSecurity's ssdeep-based operator is not implemented in Coraza.)
 	{
 		Name:    "ipMatchFromDataset",
 		Summary: "Match client IP against a dataset of IP addresses and CIDR ranges",

--- a/internal/knowledge/transformations.go
+++ b/internal/knowledge/transformations.go
@@ -106,13 +106,10 @@ var allTransformations = []Item{
 		Example:     `SecRule TX:data "@rx 3c73637" "id:13,phase:2,deny,t:hexEncode"`,
 		Description: "**hexEncode** converts each byte to its two-character lowercase hexadecimal representation.",
 	},
-	{
-		Name:        "sqlHexDecode",
-		Summary:     "Decode SQL hex notation (0x414243 format)",
-		Syntax:      "t:sqlHexDecode",
-		Example:     `SecRule ARGS "@rx select" "id:14,phase:2,deny,t:sqlHexDecode,t:lowercase"`,
-		Description: "**sqlHexDecode** decodes SQL hex-encoded strings in `0xHH...` format used in SQL injection attacks.",
-	},
+	// Note: `sqlHexDecode` is intentionally absent. Coraza v3.5.0 does NOT
+	// register it (it exists only as testdata in internal/transformations/
+	// testdata/sqlHexDecode.json, with no implementation), so Coraza rejects
+	// `t:sqlHexDecode` at parse time with `invalid transformation name`.
 	{
 		Name:        "escapeSeqDecode",
 		Summary:     "Decode ANSI C escape sequences",

--- a/internal/knowledge/variables.go
+++ b/internal/knowledge/variables.go
@@ -279,13 +279,10 @@ var allVariables = []Item{
 		Example:     `SecRule REMOTE_PORT "@lt 1024" "id:62,phase:1,pass,log"`,
 		Description: "**REMOTE_PORT** contains the TCP source port number of the client connection.",
 	},
-	{
-		Name:        "REMOTE_USER",
-		Summary:     "Authenticated username",
-		Syntax:      "REMOTE_USER",
-		Example:     `SecRule REMOTE_USER "@streq admin" "id:63,phase:1,pass,log"`,
-		Description: "**REMOTE_USER** contains the username from HTTP authentication, if any.",
-	},
+	// Note: `REMOTE_USER` is intentionally absent. Coraza v3.5.0's variable
+	// parser (internal/variables/variablesmap.gen.go) does not recognise it and
+	// rejects `SecRule REMOTE_USER ...` with `unknown variable`. The
+	// authenticated identity is exposed via the USERID variable instead.
 	{
 		Name:        "SERVER_ADDR",
 		Summary:     "Server IP address",
@@ -438,13 +435,10 @@ var allVariables = []Item{
 		Example:     `SecAction "id:111,phase:1,pass,initcol:IP=%{REMOTE_ADDR}"`,
 		Description: "**IP** is a persistent collection keyed by IP address. Data survives across requests from the same client IP. Requires `initcol:IP=...` to initialize.",
 	},
-	{
-		Name:        "SESSION",
-		Summary:     "Persistent per-session collection",
-		Syntax:      "SESSION[:key]",
-		Example:     `SecAction "id:112,phase:1,pass,setsid:%{REQUEST_COOKIES:session}"`,
-		Description: "**SESSION** is a persistent collection keyed by session token. Data survives across requests in the same session. Initialize with `setsid`.",
-	},
+	// Note: `SESSION` is intentionally absent. Coraza v3.5.0's variable parser
+	// does not recognise a bare `SESSION` variable and rejects it with `unknown
+	// variable`. The persistent session collection is keyed through the
+	// SESSIONID variable instead.
 	{
 		Name:        "GEO",
 		Summary:     "Geolocation data populated by @geoLookup operator",


### PR DESCRIPTION
The compiled-in knowledge base (LSP's source of truth for "unknown X" diagnostics) had drifted from what Coraza actually supports, causing both false positives and false negatives on real rule sets. Every entry was verified against **the exact Coraza version this module builds (v3.5.0)** by compiling a probe through `coraza.NewWAF(...WithDirectives())`.

### Removed — Coraza v3.5.0 rejects these (were false negatives hiding real errors)
actions `accuracy`, `proxy`, `pause`; transformation `sqlHexDecode`; operators `@ne`, `@containsWord`, `@verifyCC`, `@fuzzyHash`; variables `REMOTE_USER`, `SESSION`; ctl `noAuditLog`.

### Added — Coraza supports, KB omitted (were false positives on real CRS)
ctl `ruleRemoveByMsg`, `ruleRemoveTargetByMsg` (+`auditLogParts`, `responseBodyProcessor`, `forceResponseBodyVariable`, `hashEngine`, `hashEnforcement`); several Coraza no-op directives (annotated + Deprecated).

### Re-tagged / annotated
`t` and `ctl` ActionType `"data"` → `"non-disruptive"` (match Coraza `Type()`); `SecRuleUpdateTargetByMsg` documented as a Coraza no-op.

### Drift guard (the audit's "kill knowledge drift" recommendation)
`internal/knowledge/drift_test.go` compiles each KB name through `coraza.NewWAF` and fails if Coraza rejects it; a reverse check logs Coraza names the KB omits (pinned to v3.5.0). Future divergence is caught in CI. Verified non-trivial (re-adding `accuracy`/`@ne` makes it fail).

Also corrected stale `analysis`/`completion` test assertions that encoded the old incorrect expectations. **CRS integration: no false positives** over 33 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)