### PR TITLE
fix(completion,config,definition,hover,symbols): remaining audit fixes

### DIFF
--- a/internal/completion/audit_fixes_test.go
+++ b/internal/completion/audit_fixes_test.go
@@ -1,0 +1,27 @@
+package completion
+
+import "testing"
+
+// A negative cursor offset (some clients send one for an out-of-range position)
+// must not panic.
+func TestDetectContext_NegativeOffsetNoPanic(t *testing.T) {
+	ctx, prefix := DetectContext("SecRule ARGS", -5)
+	_ = ctx
+	_ = prefix // just assert it returned without panicking
+}
+
+// Inside the operator argument (after `@op `), context is ContextOperatorArg,
+// not ContextOperator (which is only for selecting the operator name).
+func TestDetectContext_OperatorArgVsName(t *testing.T) {
+	// Cursor still on the operator name.
+	ctx, _ := DetectContext(`SecRule ARGS "@r`, len(`SecRule ARGS "@r`))
+	if ctx != ContextOperator {
+		t.Fatalf("typing operator name: got %v, want ContextOperator", ctx)
+	}
+	// Cursor in the operator argument.
+	line := `SecRule ARGS "@rx `
+	ctx, _ = DetectContext(line, len(line))
+	if ctx != ContextOperatorArg {
+		t.Fatalf("inside operator arg: got %v, want ContextOperatorArg", ctx)
+	}
+}

--- a/internal/completion/context.go
+++ b/internal/completion/context.go
@@ -58,7 +58,11 @@ const (
 // line is the full text of the current line; cursorChar is the 0-indexed
 // character offset of the cursor within that line.
 func DetectContext(line string, cursorChar int) (ctx CompletionContext, prefix string) {
-	// Clamp cursor to line length.
+	// Clamp cursor into range. A negative offset (which some clients can send
+	// for an out-of-range position) would otherwise panic on line[:cursorChar].
+	if cursorChar < 0 {
+		cursorChar = 0
+	}
 	if cursorChar > len(line) {
 		cursorChar = len(line)
 	}
@@ -148,7 +152,14 @@ func contextInSecRule(argTokens []string, fullText, prefix string) (CompletionCo
 	if insideQuote {
 		switch completedQuotes {
 		case 0:
-			// Cursor is inside the first quoted arg → operator context.
+			// Cursor is inside the first quoted arg. If the operator name is
+			// already typed and followed by whitespace (e.g. `"@rx |`), the
+			// cursor is in the operator ARGUMENT, not still selecting the
+			// operator name.
+			if openQuoteContent(textFromVars) != "" && inOperatorArg(openQuoteContent(textFromVars)) {
+				return ContextOperatorArg, ""
+			}
+			// Otherwise the cursor is still selecting the @operator name.
 			return ContextOperator, strings.TrimLeft(prefix, "! @")
 		case 1:
 			// Cursor is inside the second quoted arg → action list.
@@ -163,6 +174,42 @@ func contextInSecRule(argTokens []string, fullText, prefix string) (CompletionCo
 		return ContextVariableList, lastSegment(prefix, '|')
 	}
 	return ContextUnknown, prefix
+}
+
+// openQuoteContent returns the text following the first '"' in s (the content of
+// the currently-open quoted argument). Returns "" if there is no '"'.
+func openQuoteContent(s string) string {
+	i := strings.IndexByte(s, '"')
+	if i < 0 {
+		return ""
+	}
+	return s[i+1:]
+}
+
+// inOperatorArg reports whether the open-quote content is past the operator name
+// (i.e. an optional '!', '@name', then whitespace) — meaning the cursor is in the
+// operator argument rather than still typing the operator name.
+func inOperatorArg(content string) bool {
+	c := strings.TrimLeft(content, " \t")
+	c = strings.TrimPrefix(c, "!")
+	if !strings.HasPrefix(c, "@") {
+		return false
+	}
+	c = c[1:]
+	n := 0
+	for n < len(c) {
+		ch := c[n]
+		isName := ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
+		if !isName {
+			break
+		}
+		n++
+	}
+	if n == 0 {
+		return false // no operator name yet
+	}
+	// Operator name is followed by whitespace → we are in the argument.
+	return n < len(c) && (c[n] == ' ' || c[n] == '\t')
 }
 
 // DetectContextInActionList detects completion context from the text of a

--- a/internal/config/audit_fixes_test.go
+++ b/internal/config/audit_fixes_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+// Merge must copy the defaults' slices, not alias them — otherwise mutating a
+// merged config's slice corrupts the shared defaults.
+func TestMerge_CopiesDefaultSlices(t *testing.T) {
+	defaults := Config{
+		FilePatterns: []string{"**/*.conf"},
+		Ignore:       []string{"**/.git/**"},
+		IncludePaths: []string{"rules"},
+	}
+	var c Config
+	c.Merge(defaults)
+
+	// Mutate the merged config's slices.
+	c.FilePatterns[0] = "MUTATED"
+	c.Ignore[0] = "MUTATED"
+	c.IncludePaths[0] = "MUTATED"
+
+	if defaults.FilePatterns[0] != "**/*.conf" ||
+		defaults.Ignore[0] != "**/.git/**" ||
+		defaults.IncludePaths[0] != "rules" {
+		t.Fatalf("Merge aliased defaults' slices; defaults were corrupted: %+v", defaults)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,13 +102,15 @@ func (c *Config) Merge(defaults Config) {
 		c.Entrypoint = defaults.Entrypoint
 	}
 	if c.IncludePaths == nil {
-		c.IncludePaths = defaults.IncludePaths
+		// Copy (not alias) the default slices so later mutation of this config's
+		// slices cannot corrupt the shared defaults' backing arrays.
+		c.IncludePaths = append([]string(nil), defaults.IncludePaths...)
 	}
 	if c.FilePatterns == nil {
-		c.FilePatterns = defaults.FilePatterns
+		c.FilePatterns = append([]string(nil), defaults.FilePatterns...)
 	}
 	if c.Ignore == nil {
-		c.Ignore = defaults.Ignore
+		c.Ignore = append([]string(nil), defaults.Ignore...)
 	}
 	if c.Diagnostics == nil {
 		c.Diagnostics = map[string]Severity{}

--- a/internal/definition/definition.go
+++ b/internal/definition/definition.go
@@ -84,7 +84,14 @@ func resolveInRule(rule *parser.RuleNode, f *parser.File, line, char int) []prot
 // baseURI is the URI of the document containing the Include directive.
 func resolveIncludePath(filesys vfs.FileSystem, path, baseURI string) string {
 	if strings.HasPrefix(path, "file://") {
-		return path
+		// Route the file:// target through the provided filesystem rather than
+		// returning it verbatim — otherwise an Include of e.g. file:///etc/passwd
+		// would bypass the embedder's VFS sandbox entirely.
+		p := strings.TrimPrefix(path, "file://")
+		if fileExists(filesys, p) {
+			return "file://" + p
+		}
+		return ""
 	}
 	if filepath.IsAbs(path) {
 		if fileExists(filesys, path) {

--- a/internal/definition/definition_test.go
+++ b/internal/definition/definition_test.go
@@ -164,10 +164,20 @@ func TestResolveIncludePath_NonExistent(t *testing.T) {
 	assert.Equal(t, "", result)
 }
 
-func TestResolveIncludePath_AlreadyURI(t *testing.T) {
+func TestResolveIncludePath_FileURIRoutedThroughFS(t *testing.T) {
 	t.Parallel()
-	result := resolveIncludePath(testFS, "file:///etc/rules.conf", "file:///etc/coraza.conf")
-	assert.Equal(t, "file:///etc/rules.conf", result)
+	// A file:// Include is routed through the provided filesystem rather than
+	// returned verbatim: a nonexistent / out-of-sandbox target resolves to "".
+	got := resolveIncludePath(testFS, "file:///etc/coraza-nonexistent-xyz.conf", "file:///etc/coraza.conf")
+	assert.Equal(t, "", got, "file:// to a nonexistent path must not be navigable (sandbox)")
+
+	// A file:// target that does exist on the filesystem resolves normally.
+	tmp, err := os.CreateTemp("", "coraza-def-fileuri-*.conf")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	tmp.Close()
+	got = resolveIncludePath(testFS, "file://"+tmp.Name(), "file:///etc/coraza.conf")
+	assert.Equal(t, "file://"+tmp.Name(), got)
 }
 
 func TestResolveIncludePath_RelativeExists(t *testing.T) {

--- a/internal/hover/audit_fixes_test.go
+++ b/internal/hover/audit_fixes_test.go
@@ -1,0 +1,46 @@
+package hover
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/parser"
+)
+
+// Hovering a %{...} macro inside an operator argument returns the macro's
+// variable doc, not the operator doc.
+func TestHover_MacroInsideOperatorArg(t *testing.T) {
+	src := `SecRule TX:foo "@rx %{TX.0}" "id:1,phase:2"`
+	f := parser.Parse("u", src)
+	col := strings.Index(src, "%{TX") + 2 // on the "TX" inside %{...}
+	res := Hover(f, src, 0, col)
+	if res == nil || !strings.Contains(strings.ToUpper(res.Contents.Value), "TX") {
+		t.Fatalf("macro hover in operator arg: got %+v, want TX variable doc", res)
+	}
+}
+
+// Hovering the `t` keyword shows the `t` action doc; hovering the value shows
+// the transformation doc.
+func TestHover_TKeywordVsValue(t *testing.T) {
+	src := `SecRule ARGS "@rx x" "id:1,t:lowercase"`
+	f := parser.Parse("u", src)
+	kw := strings.Index(src, "t:lowercase") // on the `t`
+	val := strings.Index(src, "lowercase")  // on the value
+
+	kwRes := Hover(f, src, 0, kw)
+	valRes := Hover(f, src, 0, val)
+	if kwRes == nil || valRes == nil {
+		t.Fatalf("expected hover results: kw=%v val=%v", kwRes, valRes)
+	}
+	// The `t` keyword shows the `t` action doc (title "## t"); the value shows
+	// the lowercase transformation doc (title "## lowercase").
+	if !strings.HasPrefix(kwRes.Contents.Value, "## t\n") {
+		t.Fatalf("hovering `t` keyword should show the `t` action doc, got: %q", kwRes.Contents.Value)
+	}
+	if !strings.Contains(valRes.Contents.Value, "## lowercase") {
+		t.Fatalf("hovering the value should show the lowercase transformation doc, got: %q", valRes.Contents.Value)
+	}
+	if kwRes.Contents.Value == valRes.Contents.Value {
+		t.Fatalf("keyword and value hovers should differ")
+	}
+}

--- a/internal/hover/hover.go
+++ b/internal/hover/hover.go
@@ -96,6 +96,15 @@ func hoverInRule(rule *parser.RuleNode, source string, line, char int) *Result {
 		}
 	}
 
+	// Macro expansion hover wins over the enclosing operator/action: %{COLLECTION...}
+	// can appear inside an operator argument or an action value, and the macro's
+	// variable doc is more specific than the operator/action doc around it.
+	if source != "" {
+		if item := macroVarAtPos(source, line, char); item != nil {
+			return buildResult(item, nil)
+		}
+	}
+
 	// Hover over the operator.
 	if rule.Operator != nil && rule.Operator.Range.ContainsPosition(line, char) {
 		// Check if hovering over operator name specifically.
@@ -121,10 +130,18 @@ func hoverInRule(rule *parser.RuleNode, source string, line, char int) *Result {
 			a := &rule.Actions[i]
 			if a.Range.ContainsPosition(line, char) {
 				name := a.LowerName()
-				// For transformation actions, hover the transformation value.
+				// For a transformation action `t:NAME`, show the transformation doc
+				// only when the cursor is on the value; on the `t` / `:` keyword
+				// itself show the `t` action doc.
 				if name == "t" && a.HasColon {
-					item := knowledge.Transformation(a.Value)
-					if item != nil {
+					valueStart := a.Range.Start.Character + 2 // past "t:"
+					onValue := line == a.Range.Start.Line && char >= valueStart
+					if onValue {
+						if item := knowledge.Transformation(a.Value); item != nil {
+							r := a.Range
+							return buildResult(item, &r)
+						}
+					} else if item := knowledge.Action("t"); item != nil {
 						r := a.Range
 						return buildResult(item, &r)
 					}
@@ -154,14 +171,6 @@ func hoverInRule(rule *parser.RuleNode, source string, line, char int) *Result {
 					return buildResult(item, nil)
 				}
 			}
-		}
-	}
-
-	// Macro expansion hover: %{COLLECTION.key} or %{COLLECTION:key} anywhere in
-	// the rule — operator argument or action values.
-	if source != "" {
-		if item := macroVarAtPos(source, line, char); item != nil {
-			return buildResult(item, nil)
 		}
 	}
 

--- a/internal/symbols/audit_fixes_test.go
+++ b/internal/symbols/audit_fixes_test.go
@@ -1,0 +1,28 @@
+package symbols
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/parser"
+)
+
+func TestWorkspaceSymbols_MatchesTagAndSkipsNoID(t *testing.T) {
+	src := strings.Join([]string{
+		`SecRule ARGS "@rx x" "id:100,phase:2,tag:'attack-sqli',chain"`,
+		`    SecRule ARGS "@rx y" "t:none"`, // chain child: no id
+	}, "\n")
+	docs := map[string]*parser.File{"file:///r.conf": parser.Parse("file:///r.conf", src)}
+
+	// Tag search finds the rule by its tag value.
+	got := WorkspaceSymbols("attack-sqli", docs)
+	if len(got) != 1 || !strings.Contains(got[0].Name, "100") {
+		t.Fatalf("tag search: got %+v, want one symbol for id 100", got)
+	}
+
+	// Listing all symbols skips the chain continuation (no id) — no bare "SecRule".
+	all := WorkspaceSymbols("", docs)
+	if len(all) != 1 {
+		t.Fatalf("got %d symbols, want 1 (no-id chain child must be skipped): %+v", len(all), all)
+	}
+}

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -47,14 +47,32 @@ func WorkspaceSymbols(query string, documents map[string]*parser.File) []protoco
 			if !ok {
 				continue
 			}
+			// Skip rules with no id: chained-rule continuations and anonymous
+			// rules would otherwise appear as a bare "SecRule" with no useful
+			// navigation target.
+			if rule.FindAction("id") == nil {
+				continue
+			}
 			label := ruleLabel(rule)
-			if query == "" || containsIgnoreCase(label, query) {
+			if query == "" || containsIgnoreCase(label, query) || ruleMatchesTag(rule, query) {
 				sym := ruleToSymbolInfo(rule, uri, label)
 				result = append(result, sym)
 			}
 		}
 	}
 	return result
+}
+
+// ruleMatchesTag reports whether any of the rule's tag action values contains
+// query (case-insensitive). query is assumed non-empty.
+func ruleMatchesTag(rule *parser.RuleNode, query string) bool {
+	for i := range rule.Actions {
+		a := &rule.Actions[i]
+		if a.LowerName() == "tag" && containsIgnoreCase(a.Value, query) {
+			return true
+		}
+	}
+	return false
 }
 
 func ruleSymbol(rule *parser.RuleNode) *protocol_3_16.DocumentSymbol {


### PR DESCRIPTION
The remaining lower-severity audit findings across the editor-feature packages (follow-up to #8). Full suite green under `-race`; vet clean.

- **completion** — `DetectContext` no longer panics on a negative cursor offset; the operator-argument position is now `ContextOperatorArg`, not `ContextOperator` (which is only for selecting the `@operator` name).
- **config** — `Config.Merge` copies the defaults' slices instead of aliasing them (mutating a merged config could corrupt the shared defaults).
- **definition** (security) — an `Include` with a `file://` URI is routed through the provided VFS instead of returned verbatim, so it can't bypass the embedder's filesystem sandbox.
- **hover** — a `%{...}` macro inside an operator argument resolves to the macro's variable doc (was: operator doc); hovering the `t` keyword shows the `t` action doc while the value shows the transformation doc.
- **symbols** — `WorkspaceSymbols` now matches rule tags (as documented) and skips chain-continuation rules with no id (no more bare "SecRule" entries).

Regression tests added for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)