### PR TITLE
fix(lsp): emit UTF-16 position columns so diagnostics land exactly (incl. emoji)

### DIFF
--- a/internal/formatting/formatter.go
+++ b/internal/formatting/formatter.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	protocol_3_16 "github.com/tliron/glsp/protocol_3_16"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 )
 
 // secLangWS is the set of intra-line whitespace bytes the SecLang lexer
@@ -52,7 +54,7 @@ func Format(source string) []protocol_3_16.TextEdit {
 	// Count lines in original for the end position.
 	lines := strings.Split(source, "\n")
 	endLine := len(lines) - 1
-	endChar := len(lines[endLine])
+	endChar := lsppos.UTF16Len(lines[endLine])
 
 	return []protocol_3_16.TextEdit{
 		{

--- a/internal/hover/hover.go
+++ b/internal/hover/hover.go
@@ -11,6 +11,7 @@ import (
 	protocol_3_16 "github.com/tliron/glsp/protocol_3_16"
 
 	"github.com/coraza-incubator/coraza-lsp/internal/knowledge"
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
 )
 
@@ -185,6 +186,8 @@ func macroVarAtPos(source string, line, char int) *knowledge.Item {
 	if line >= len(lines) {
 		return nil
 	}
+	// char arrives as a UTF-16 column; convert to a rune index for runes[].
+	char = lsppos.UTF16ColumnToRune(lines[line], char)
 	runes := []rune(lines[line])
 	if char >= len(runes) {
 		return nil
@@ -220,6 +223,8 @@ func wordAtPos(source string, line, char int) string {
 	if line >= len(lines) {
 		return ""
 	}
+	// char arrives as a UTF-16 column; convert to a rune index for runes[].
+	char = lsppos.UTF16ColumnToRune(lines[line], char)
 	runes := []rune(lines[line])
 	if char >= len(runes) {
 		return ""

--- a/internal/lsppos/lsppos.go
+++ b/internal/lsppos/lsppos.go
@@ -1,0 +1,73 @@
+// Copyright 2026 OWASP Coraza
+// Author: Juan Pablo Tosso <pablo@owasp.org>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package lsppos converts between the byte/rune view of source text and the
+// UTF-16 code-unit columns the Language Server Protocol uses for the `character`
+// field of a Position.
+//
+// LSP's default (and the only universally-supported) position encoding is
+// UTF-16 code units, NOT bytes and NOT Unicode code points. For BMP characters
+// (which includes virtually everything an AI tends to emit into a config file —
+// smart quotes, em dashes, accents, arrows, CJK) one rune is exactly one UTF-16
+// unit, so rune counting happens to be correct. But astral-plane characters
+// (emoji such as U+1F600, mathematical alphanumerics, …) are a single rune yet
+// TWO UTF-16 code units, so rune counting drifts and a diagnostic/hover lands on
+// the wrong column. These helpers make the column exact for all of Unicode.
+package lsppos
+
+// UTF16Len returns the number of UTF-16 code units needed to encode s.
+func UTF16Len(s string) int {
+	n := 0
+	for _, r := range s {
+		if r > 0xFFFF {
+			n += 2 // encoded as a surrogate pair
+		} else {
+			n++
+		}
+	}
+	return n
+}
+
+// UTF16ColumnToByte maps a UTF-16 column within line to a byte offset into line.
+// Out-of-range columns are clamped to [0, len(line)]. If the column falls in the
+// middle of a surrogate pair (which a well-behaved client never sends) it rounds
+// up to the byte after the offending rune.
+func UTF16ColumnToByte(line string, col int) int {
+	if col <= 0 {
+		return 0
+	}
+	units := 0
+	for i, r := range line {
+		if units >= col {
+			return i
+		}
+		if r > 0xFFFF {
+			units += 2
+		} else {
+			units++
+		}
+	}
+	return len(line)
+}
+
+// UTF16ColumnToRune maps a UTF-16 column within line to a rune index into line
+// (i.e. an index into []rune(line)). Clamped to the line's rune count.
+func UTF16ColumnToRune(line string, col int) int {
+	if col <= 0 {
+		return 0
+	}
+	units, runes := 0, 0
+	for _, r := range line {
+		if units >= col {
+			return runes
+		}
+		if r > 0xFFFF {
+			units += 2
+		} else {
+			units++
+		}
+		runes++
+	}
+	return runes
+}

--- a/internal/lsppos/lsppos_test.go
+++ b/internal/lsppos/lsppos_test.go
@@ -1,0 +1,57 @@
+package lsppos
+
+import "testing"
+
+func TestUTF16Len(t *testing.T) {
+	cases := []struct {
+		s    string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"café", 4},     // é is BMP: 1 unit
+		{"€", 1},        // BMP
+		{"中文", 2},       // BMP CJK
+		{"a😀b", 4},      // 😀 (U+1F600) is astral: 2 units
+		{"😀😀", 4},       // two astral chars
+		{"x→y", 3},      // → is BMP
+	}
+	for _, c := range cases {
+		if got := UTF16Len(c.s); got != c.want {
+			t.Errorf("UTF16Len(%q) = %d, want %d", c.s, got, c.want)
+		}
+	}
+}
+
+func TestUTF16ColumnToByte(t *testing.T) {
+	// "a😀b": bytes a=1, 😀=4, b=1; UTF-16 units a=1, 😀=2, b=1.
+	const s = "a😀b"
+	cases := []struct{ col, want int }{
+		{0, 0},
+		{1, 1}, // start of 😀
+		{3, 5}, // after 😀 (2 units), start of b at byte 5
+		{4, 6}, // end
+		{99, 6},
+		{-1, 0},
+	}
+	for _, c := range cases {
+		if got := UTF16ColumnToByte(s, c.col); got != c.want {
+			t.Errorf("UTF16ColumnToByte(%q,%d) = %d, want %d", s, c.col, got, c.want)
+		}
+	}
+}
+
+func TestUTF16ColumnToRune(t *testing.T) {
+	const s = "a😀b" // runes: a=0,😀=1,b=2 ; utf16: a=0,😀=1..2,b=3
+	cases := []struct{ col, want int }{
+		{0, 0},
+		{1, 1}, // 😀
+		{3, 2}, // b (after 2 units of 😀)
+		{4, 3},
+	}
+	for _, c := range cases {
+		if got := UTF16ColumnToRune(s, c.col); got != c.want {
+			t.Errorf("UTF16ColumnToRune(%q,%d) = %d, want %d", s, c.col, got, c.want)
+		}
+	}
+}

--- a/internal/parser/actions.go
+++ b/internal/parser/actions.go
@@ -5,8 +5,8 @@
 package parser
 
 import (
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 	"strings"
-	"unicode/utf8"
 )
 
 // parseActions parses an action list string into ActionExpr nodes.
@@ -68,7 +68,7 @@ func parseSingleAction(s string, start Position) ActionExpr {
 		expr.Value = unquoteSingle(raw)
 	}
 
-	endChar := start.Character + utf8.RuneCountInString(s)
+	endChar := start.Character + lsppos.UTF16Len(s)
 	expr.Range = Range{
 		Start: start,
 		End:   Position{Line: start.Line, Character: endChar},

--- a/internal/parser/fuzz_test.go
+++ b/internal/parser/fuzz_test.go
@@ -20,59 +20,59 @@ var seedCorpus = []string{
 	"\n\n\n",
 	"\r\n",
 	"\uFEFFSecRuleEngine On\n", // BOM + valid directive
-	`SecRule ARGS "@rx x" "id:1,,phase:2,deny"`,                     // double comma
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,"`,                     // trailing comma
-	`SecRule ARGS "@rx x" ",id:1,phase:2,deny"`,                     // leading comma
-	`SecRule ARGS "@rx x" "id:1 phase:2 deny"`,                      // missing commas
-	`SecRule ARGS "@rx x" 'id:1,phase:2,deny'`,                      // single-quoted actions
-	`SecRule ARGS '@rx x' "id:1,phase:2,deny"`,                      // single-quoted operator
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:'it\'s ok'"`,       // escaped quote inside
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:'unclosed`,         // unclosed msg
-	`SecRule ARGS "@rx "`,                                           // empty operator arg, no actions
-	`SecRule`,                                                       // only directive
-	`SecRule ARGS`,                                                  // one arg
-	`SecRule ARGS "@rx x"`,                                          // no actions
-	`SecRule ARGS "@rx x" ""`,                                       // empty actions
-	`SecRule ARGS|!ARGS:password "@rx x" "id:1,phase:2,deny"`,       // variable exclusion
-	`SecRule &ARGS "@eq 0" "id:1,phase:2,deny"`,                     // count prefix
-	`SecRule ARGS:foo.bar "@rx x" "id:1,phase:2,deny"`,              // dotted selector (typo)
-	`SecRule ARGS.foo "@rx x" "id:1,phase:2,deny"`,                  // dot-instead-of-colon
-	`SecRule ARGS:'quoted key' "@rx x" "id:1,phase:2,deny"`,         // quoted selector
-	`SecRule ARGS "@@rx x" "id:1,phase:2,deny"`,                     // double @
-	`SecRule ARGS "!@rx x" "id:1,phase:2,deny"`,                     // negated op
-	`SecRule ARGS "! @rx x" "id:1,phase:2,deny"`,                    // negated op with space
-	`SecRule ARGS "@rxpattern" "id:1,phase:2,deny"`,                 // op name and arg fused
-	`secrule args "@rx x" "id:1,phase:2,deny"`,                      // lowercase directive
-	`SECRULE ARGS "@rx x" "id:1,phase:2,deny"`,                      // uppercase directive
-	"SecRule ARGS \"@rx x\" \\\n  \"id:1,phase:2,deny\"",            // continuation
-	"SecRule ARGS \"@rx x\" \\\n\\\n  \"id:1,phase:2,deny\"",        // blank continuation
-	"SecRule ARGS \"@rx x\" \\",                                     // dangling continuation
-	"SecRuleEngine On\r\nSecRuleEngine Off\r\n",                     // CRLF
-	`SecMarker`,                                                     // marker no name
-	`SecMarker "quoted name"`,                                       // marker quoted
-	`SecMarker 'with spaces'`,                                       // marker single-quoted w/ space
-	`Include`,                                                       // include no path
-	`Include rules/*.conf`,                                          // wildcard include
-	`Include "rules with spaces.conf"`,                              // quoted include path
-	`SecAction`,                                                     // bare SecAction
-	`SecAction "id:1,phase:1,pass,chain"`,                           // chain on SecAction
-	`SecRule ARGS "@rx x" "id:1,phase:2,pass,ctl:"`,                 // empty ctl
-	`SecRule ARGS "@rx x" "id:1,phase:2,pass,ctl:ruleRemoveById"`,   // ctl without =value
-	`SecRule ARGS "@rx x" "id:1,phase:2,pass,ctl:ruleRemoveById="`,  // ctl with empty value
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,t:"`,                   // empty t:
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,t:,t:lowercase"`,       // t: then more
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:"`,                 // empty msg
+	`SecRule ARGS "@rx x" "id:1,,phase:2,deny"`,               // double comma
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,"`,               // trailing comma
+	`SecRule ARGS "@rx x" ",id:1,phase:2,deny"`,               // leading comma
+	`SecRule ARGS "@rx x" "id:1 phase:2 deny"`,                // missing commas
+	`SecRule ARGS "@rx x" 'id:1,phase:2,deny'`,                // single-quoted actions
+	`SecRule ARGS '@rx x' "id:1,phase:2,deny"`,                // single-quoted operator
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:'it\'s ok'"`, // escaped quote inside
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:'unclosed`,   // unclosed msg
+	`SecRule ARGS "@rx "`,                                     // empty operator arg, no actions
+	`SecRule`,                                                 // only directive
+	`SecRule ARGS`,                                            // one arg
+	`SecRule ARGS "@rx x"`,                                    // no actions
+	`SecRule ARGS "@rx x" ""`,                                 // empty actions
+	`SecRule ARGS|!ARGS:password "@rx x" "id:1,phase:2,deny"`, // variable exclusion
+	`SecRule &ARGS "@eq 0" "id:1,phase:2,deny"`,               // count prefix
+	`SecRule ARGS:foo.bar "@rx x" "id:1,phase:2,deny"`,        // dotted selector (typo)
+	`SecRule ARGS.foo "@rx x" "id:1,phase:2,deny"`,            // dot-instead-of-colon
+	`SecRule ARGS:'quoted key' "@rx x" "id:1,phase:2,deny"`,   // quoted selector
+	`SecRule ARGS "@@rx x" "id:1,phase:2,deny"`,               // double @
+	`SecRule ARGS "!@rx x" "id:1,phase:2,deny"`,               // negated op
+	`SecRule ARGS "! @rx x" "id:1,phase:2,deny"`,              // negated op with space
+	`SecRule ARGS "@rxpattern" "id:1,phase:2,deny"`,           // op name and arg fused
+	`secrule args "@rx x" "id:1,phase:2,deny"`,                // lowercase directive
+	`SECRULE ARGS "@rx x" "id:1,phase:2,deny"`,                // uppercase directive
+	"SecRule ARGS \"@rx x\" \\\n  \"id:1,phase:2,deny\"",      // continuation
+	"SecRule ARGS \"@rx x\" \\\n\\\n  \"id:1,phase:2,deny\"",  // blank continuation
+	"SecRule ARGS \"@rx x\" \\",                               // dangling continuation
+	"SecRuleEngine On\r\nSecRuleEngine Off\r\n",               // CRLF
+	`SecMarker`,                                     // marker no name
+	`SecMarker "quoted name"`,                       // marker quoted
+	`SecMarker 'with spaces'`,                       // marker single-quoted w/ space
+	`Include`,                                       // include no path
+	`Include rules/*.conf`,                          // wildcard include
+	`Include "rules with spaces.conf"`,              // quoted include path
+	`SecAction`,                                     // bare SecAction
+	`SecAction "id:1,phase:1,pass,chain"`,           // chain on SecAction
+	`SecRule ARGS "@rx x" "id:1,phase:2,pass,ctl:"`, // empty ctl
+	`SecRule ARGS "@rx x" "id:1,phase:2,pass,ctl:ruleRemoveById"`,  // ctl without =value
+	`SecRule ARGS "@rx x" "id:1,phase:2,pass,ctl:ruleRemoveById="`, // ctl with empty value
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,t:"`,                  // empty t:
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,t:,t:lowercase"`,      // t: then more
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:"`,                // empty msg
 	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:\"he said \\\"hi\\\"\""`,
 	`SecRule ARGS "@rx \"double-quoted pattern\"" "id:1,phase:2,deny"`,
 	"SecRule ARGS \"@rx x\" \"id:1,phase:2,deny,msg:'with\ttab'\"", // tab inside msg
-	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:'naïve utf8 😀'"`,   // non-ASCII
-	`SecRule ARGS "@rx (?:[a-z]+)\\\\(?:x+)" "id:1,phase:2,deny"`,   // regex backslashes
+	`SecRule ARGS "@rx x" "id:1,phase:2,deny,msg:'naïve utf8 😀'"`,  // non-ASCII
+	`SecRule ARGS "@rx (?:[a-z]+)\\\\(?:x+)" "id:1,phase:2,deny"`,  // regex backslashes
 	`# comment only`,
 	`# comment
 SecRuleEngine On`,
 	`SecRuleEngine On # trailing comment`,
-	`phase:2`,   // action outside a rule context
-	`id:1001`,   // ditto
+	`phase:2`, // action outside a rule context
+	`id:1001`, // ditto
 	`"just quotes"`,
 	`""`,
 	`\\`,

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -5,8 +5,8 @@
 package parser
 
 import (
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 	"strings"
-	"unicode/utf8"
 )
 
 // Lexer tokenizes a SecLang source string.
@@ -50,7 +50,7 @@ func (l *Lexer) Tokenize() []Token {
 				Value:     line,
 				Line:      physLine,
 				StartChar: 0,
-				EndChar:   utf8.RuneCountInString(line),
+				EndChar:   lsppos.UTF16Len(line),
 			})
 			physLine++
 			continue
@@ -127,7 +127,7 @@ func tokenizeLogical(logical string, startLine int, lineMap []int, physLines []s
 		Value:     word,
 		Line:      physL,
 		StartChar: physC,
-		EndChar:   physC + utf8.RuneCountInString(word),
+		EndChar:   physC + lsppos.UTF16Len(word),
 	})
 
 	// Subsequent tokens: arguments (words or quoted strings).
@@ -152,7 +152,7 @@ func tokenizeLogical(logical string, startLine int, lineMap []int, physLines []s
 				Value:     word,
 				Line:      physL,
 				StartChar: physC,
-				EndChar:   physC + utf8.RuneCountInString(word),
+				EndChar:   physC + lsppos.UTF16Len(word),
 			})
 		}
 	}
@@ -163,9 +163,9 @@ func tokenizeLogical(logical string, startLine int, lineMap []int, physLines []s
 // logicalScanner scans a logical line with position tracking back to physical lines.
 type logicalScanner struct {
 	logical   string
-	pos       int    // byte position in logical
-	startLine int    // physical line of first part
-	lineMap   []int  // physical line index for each segment
+	pos       int   // byte position in logical
+	startLine int   // physical line of first part
+	lineMap   []int // physical line index for each segment
 	physLines []string
 }
 
@@ -302,12 +302,12 @@ func (s *logicalScanner) segmentBoundary(i int) int {
 
 // physPos maps a byte position in the logical line to (physicalLine, charOffset).
 // This is an approximation that works for the common case:
-// - Single-line directives map directly.
-// - Multi-line (continuation) directives: the position is in the first physical line
-//   unless it exceeds that line's length, in which case we advance to the next.
+//   - Single-line directives map directly.
+//   - Multi-line (continuation) directives: the position is in the first physical line
+//     unless it exceeds that line's length, in which case we advance to the next.
 func (s *logicalScanner) physPos(logicalByte int) (line, char int) {
 	if len(s.lineMap) == 1 {
-		return s.lineMap[0], utf8.RuneCountInString(s.physLines[s.lineMap[0]][:min(logicalByte, len(s.physLines[s.lineMap[0]]))])
+		return s.lineMap[0], lsppos.UTF16Len(s.physLines[s.lineMap[0]][:min(logicalByte, len(s.physLines[s.lineMap[0]]))])
 	}
 	// For continuation lines, walk through segments.
 	// Each non-last segment contributes exactly len(physLines[i]) bytes to the
@@ -326,7 +326,7 @@ func (s *logicalScanner) physPos(logicalByte int) (line, char int) {
 			if localByte > len(src) {
 				localByte = len(src)
 			}
-			return physIdx, utf8.RuneCountInString(src[:localByte])
+			return physIdx, lsppos.UTF16Len(src[:localByte])
 		}
 		offset += segLen
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5,8 +5,8 @@
 package parser
 
 import (
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 	"strings"
-	"unicode/utf8"
 )
 
 // Parse parses a SecLang source file into an AST.
@@ -252,7 +252,7 @@ func parseOperator(s string, start Position, line int) (OperatorExpr, *ParseErro
 		// No @ prefix: treat whole string as a regex pattern (implicit @rx).
 		op.Name = "rx"
 		op.Argument = s[pos:]
-		endChar := start.Character + utf8.RuneCountInString(s)
+		endChar := start.Character + lsppos.UTF16Len(s)
 		op.Range = Range{Start: start, End: Position{Line: line, Character: endChar}}
 		op.NameRange = op.Range
 		return op, nil
@@ -270,7 +270,7 @@ func parseOperator(s string, start Position, line int) (OperatorExpr, *ParseErro
 			Message: "expected operator name after @",
 			Range: Range{
 				Start: start,
-				End:   Position{Line: line, Character: start.Character + utf8.RuneCountInString(s)},
+				End:   Position{Line: line, Character: start.Character + lsppos.UTF16Len(s)},
 			},
 		}
 	}
@@ -280,7 +280,7 @@ func parseOperator(s string, start Position, line int) (OperatorExpr, *ParseErro
 	if op.Negated {
 		negOffset = 1
 	}
-	nameRuneLen := utf8.RuneCountInString(op.Name)
+	nameRuneLen := lsppos.UTF16Len(op.Name)
 	op.NameRange = Range{
 		Start: Position{Line: line, Character: start.Character + negOffset + 1}, // +1 for @
 		End:   Position{Line: line, Character: start.Character + negOffset + 1 + nameRuneLen},
@@ -292,7 +292,7 @@ func parseOperator(s string, start Position, line int) (OperatorExpr, *ParseErro
 	}
 	op.Argument = s[pos:]
 
-	endChar := start.Character + utf8.RuneCountInString(s)
+	endChar := start.Character + lsppos.UTF16Len(s)
 	op.Range = Range{Start: start, End: Position{Line: line, Character: endChar}}
 
 	return op, nil
@@ -338,7 +338,6 @@ func collectArgTokens(tokens []Token) []Token {
 	}
 	return args
 }
-
 
 // directiveRange computes the Range covering all tokens in a group.
 func directiveRange(group []Token) Range {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -300,12 +300,12 @@ func TestParse_ToleratesBadLine(t *testing.T) {
 func TestParse_SecRuleArgumentCounts(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		src           string
-		wantVars      bool // expect variables parsed
-		wantOp        bool // expect operator parsed
-		wantActions   bool // expect actions parsed
-		wantParseErr  bool // expect a parse error
+		name         string
+		src          string
+		wantVars     bool // expect variables parsed
+		wantOp       bool // expect operator parsed
+		wantActions  bool // expect actions parsed
+		wantParseErr bool // expect a parse error
 	}{
 		{
 			// 0 args: just the directive keyword
@@ -334,30 +334,30 @@ func TestParse_SecRuleArgumentCounts(t *testing.T) {
 		{
 			// 4th arg is a properly closed quoted string — silently ignored,
 			// no parse error, the rule parses correctly from args 0-2.
-			name:        "4 args — extra closed quoted arg is silently ignored",
-			src:         `SecRule ARGS "@rx test" "id:1,phase:2,deny" "extra"`,
-			wantVars:    true,
-			wantOp:      true,
-			wantActions: true,
+			name:         "4 args — extra closed quoted arg is silently ignored",
+			src:          `SecRule ARGS "@rx test" "id:1,phase:2,deny" "extra"`,
+			wantVars:     true,
+			wantOp:       true,
+			wantActions:  true,
 			wantParseErr: false,
 		},
 		{
 			// 4th arg is an UNCLOSED quoted string — the pre-scan catches it
 			// and fires a parse error even though it's beyond arg[2].
-			name:        "4 args — extra unclosed quoted arg fires parse-error",
-			src:         `SecRule ARGS "@rx test" "id:1,phase:2,deny" "extra`,
-			wantVars:    true,
-			wantOp:      true,
-			wantActions: true,
+			name:         "4 args — extra unclosed quoted arg fires parse-error",
+			src:          `SecRule ARGS "@rx test" "id:1,phase:2,deny" "extra`,
+			wantVars:     true,
+			wantOp:       true,
+			wantActions:  true,
 			wantParseErr: true,
 		},
 		{
 			// 4th arg is an unquoted word — silently ignored (word beyond arg[2]).
-			name:        "4 args — extra unquoted word is silently ignored",
-			src:         `SecRule ARGS "@rx test" "id:1,phase:2,deny" extra_word`,
-			wantVars:    true,
-			wantOp:      true,
-			wantActions: true,
+			name:         "4 args — extra unquoted word is silently ignored",
+			src:          `SecRule ARGS "@rx test" "id:1,phase:2,deny" extra_word`,
+			wantVars:     true,
+			wantOp:       true,
+			wantActions:  true,
 			wantParseErr: false,
 		},
 	}
@@ -495,10 +495,10 @@ func TestParse_OperatorEdgeCases(t *testing.T) {
 func TestParse_VariableListEdgeCases(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name         string
-		varStr       string  // variable string passed to parseVariables
-		wantCount    int     // number of VariableExpr expected
-		wantErrPart  string  // substring of expected parse error, or "" for none
+		name        string
+		varStr      string // variable string passed to parseVariables
+		wantCount   int    // number of VariableExpr expected
+		wantErrPart string // substring of expected parse error, or "" for none
 	}{
 		{
 			// Trailing pipe — empty segment at end is silently skipped
@@ -543,7 +543,7 @@ func TestParse_VariableListEdgeCases(t *testing.T) {
 			// Multiple variables with a bare prefix in the middle
 			name:        "ARGS|!|FILES — bare ! in middle yields error and skips that segment",
 			varStr:      "ARGS|!|FILES",
-			wantCount:   2,  // ARGS and FILES parsed; ! segment errors
+			wantCount:   2, // ARGS and FILES parsed; ! segment errors
 			wantErrPart: "expected variable name after prefix",
 		},
 		{
@@ -610,9 +610,9 @@ func TestParse_VariableListEdgeCases(t *testing.T) {
 func TestParse_ActionListEdgeCases(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name        string
-		actionStr   string // content inside the outer double quotes
-		wantCount   int    // expected number of ActionExpr
+		name      string
+		actionStr string // content inside the outer double quotes
+		wantCount int    // expected number of ActionExpr
 	}{
 		{
 			// Empty action list — zero actions, not an error at the parser level.
@@ -751,9 +751,9 @@ func TestParse_ContinuationEdgeCases(t *testing.T) {
 func TestParse_CaseInsensitiveDirectives(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		src       string
-		wantKind  NodeKind
+		name     string
+		src      string
+		wantKind NodeKind
 	}{
 		{
 			name:     "SECRULE uppercase — parsed as SecRule",
@@ -902,20 +902,20 @@ func TestParse_ExtraTrailingQuote(t *testing.T) {
 		},
 		{
 			// Single trailing " after a normally closed action list
-			name: "single trailing quote after closed action list",
-			src:  `SecRule ARGS "@rx test" "id:1001,phase:2,deny"` + `"`,
+			name:        "single trailing quote after closed action list",
+			src:         `SecRule ARGS "@rx test" "id:1001,phase:2,deny"` + `"`,
 			wantErrPart: "unclosed string literal",
 		},
 		{
 			// Extra trailing " on SecAction
-			name: "trailing quote after SecAction",
-			src:  `SecAction "id:1000,phase:1,pass,nolog"` + `"`,
+			name:        "trailing quote after SecAction",
+			src:         `SecAction "id:1000,phase:1,pass,nolog"` + `"`,
 			wantErrPart: "unclosed string literal",
 		},
 		{
 			// Double closing quotes on SecDefaultAction
-			name: "double closing quotes on SecDefaultAction",
-			src:  `SecDefaultAction "phase:2,deny,log""`,
+			name:        "double closing quotes on SecDefaultAction",
+			src:         `SecDefaultAction "phase:2,deny,log""`,
 			wantErrPart: "unclosed string literal",
 		},
 		{
@@ -1033,8 +1033,8 @@ func TestParse_ChainRules(t *testing.T) {
 		wantChains []bool // IsChained for each RuleNode in order
 	}{
 		{
-			name: "single rule — not chained",
-			src:  `SecRule ARGS "@rx x" "id:1,phase:2,deny"`,
+			name:       "single rule — not chained",
+			src:        `SecRule ARGS "@rx x" "id:1,phase:2,deny"`,
 			wantChains: []bool{false},
 		},
 		{
@@ -1190,11 +1190,11 @@ func TestParse_XMLXPathKey(t *testing.T) {
 func TestParse_VariableWildcard(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name       string
-		src        string
-		wantName   string
-		wantKey    string
-		wantErr    bool
+		name     string
+		src      string
+		wantName string
+		wantKey  string
+		wantErr  bool
 	}{
 		{
 			name:     "REQUEST_COOKIES* — wildcard no colon",

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -12,7 +12,7 @@
 // All positions are 0-indexed (line and character) following the LSP convention.
 package parser
 
-import "unicode/utf8"
+import "github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 
 // TokenType classifies a scanned token.
 type TokenType int
@@ -73,7 +73,7 @@ type Token struct {
 // values that span multiple physical lines.
 //
 // valueByte is a BYTE offset into Token.Value, but the returned char is a RUNE
-// column (matching the lexer, which reports columns as utf8.RuneCountInString).
+// column (matching the lexer, which reports columns as lsppos.UTF16Len).
 // We therefore convert the byte offset into a rune count relative to the start
 // of the active physical segment before adding it to that segment's start column,
 // so that multibyte content earlier in the value (e.g. msg:'café') does not shift
@@ -99,6 +99,6 @@ func (t Token) PhysPos(valueByte int) (physLine, physChar int) {
 		startCol = b.PhysChar
 		segByte = b.ValueByte
 	}
-	runeOff := utf8.RuneCountInString(t.Value[segByte:valueByte])
+	runeOff := lsppos.UTF16Len(t.Value[segByte:valueByte])
 	return line, startCol + runeOff
 }

--- a/internal/parser/utf16_pos_test.go
+++ b/internal/parser/utf16_pos_test.go
@@ -1,0 +1,42 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
+)
+
+// Positions must be reported in UTF-16 code units (the LSP default encoding), so
+// an astral-plane character (emoji = 1 rune but 2 UTF-16 units) before a token
+// shifts that token's column by the extra unit. This is what lets a client put
+// the squiggle on exactly the right spot even in AI-generated rules full of
+// emoji / unusual Unicode.
+func TestActionColumns_UTF16AstralExact(t *testing.T) {
+	src := `SecAction "id:1,phase:2,msg:'😀',deny"`
+	f := Parse("u", src)
+	if len(f.Nodes) == 0 {
+		t.Fatal("no nodes parsed")
+	}
+	rule, ok := f.Nodes[0].(*RuleNode)
+	if !ok {
+		t.Fatalf("expected RuleNode, got %T", f.Nodes[0])
+	}
+
+	var deny *ActionExpr
+	for i := range rule.Actions {
+		if rule.Actions[i].Name == "deny" {
+			deny = &rule.Actions[i]
+		}
+	}
+	if deny == nil {
+		t.Fatal("deny action not found")
+	}
+
+	// The expected column is the UTF-16 length of everything before "deny".
+	want := lsppos.UTF16Len(src[:strings.Index(src, "deny")])
+	if deny.Range.Start.Character != want {
+		t.Fatalf("deny column = %d, want %d (UTF-16). Rune-based code would report %d",
+			deny.Range.Start.Character, want, want-1)
+	}
+}

--- a/internal/parser/variables.go
+++ b/internal/parser/variables.go
@@ -5,9 +5,9 @@
 package parser
 
 import (
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 	"strconv"
 	"strings"
-	"unicode/utf8"
 )
 
 // ParseVariables parses a SecRule variable list string into VariableExpr nodes.
@@ -30,12 +30,12 @@ func ParseVariables(s string, offset Position) ([]VariableExpr, []ParseError) {
 	for _, part := range parts {
 		trimmed := strings.TrimSpace(part)
 		if trimmed == "" {
-			charOffset += utf8.RuneCountInString(part) + 1 // +1 for pipe
+			charOffset += lsppos.UTF16Len(part) + 1 // +1 for pipe
 			continue
 		}
 
 		// Track the start position of this variable in the source.
-		leadingSpaces := utf8.RuneCountInString(part) - utf8.RuneCountInString(strings.TrimLeft(part, " \t"))
+		leadingSpaces := lsppos.UTF16Len(part) - lsppos.UTF16Len(strings.TrimLeft(part, " \t"))
 		varStart := Position{Line: offset.Line, Character: charOffset + leadingSpaces}
 
 		expr, err := parseSingleVariable(trimmed, varStart, offset.Line)
@@ -45,7 +45,7 @@ func ParseVariables(s string, offset Position) ([]VariableExpr, []ParseError) {
 			exprs = append(exprs, expr)
 		}
 
-		charOffset += utf8.RuneCountInString(part) + 1 // +1 for pipe separator
+		charOffset += lsppos.UTF16Len(part) + 1 // +1 for pipe separator
 	}
 
 	return exprs, errs
@@ -73,7 +73,7 @@ func parseSingleVariable(s string, start Position, line int) (VariableExpr, *Par
 			Message: "expected variable name after prefix",
 			Range: Range{
 				Start: start,
-				End:   Position{Line: line, Character: start.Character + utf8.RuneCountInString(s)},
+				End:   Position{Line: line, Character: start.Character + lsppos.UTF16Len(s)},
 			},
 		}
 	}
@@ -97,7 +97,7 @@ func parseSingleVariable(s string, start Position, line int) (VariableExpr, *Par
 				Message: msg,
 				Range: Range{
 					Start: start,
-					End:   Position{Line: line, Character: start.Character + utf8.RuneCountInString(s)},
+					End:   Position{Line: line, Character: start.Character + lsppos.UTF16Len(s)},
 				},
 			}
 		}
@@ -110,7 +110,7 @@ func parseSingleVariable(s string, start Position, line int) (VariableExpr, *Par
 			Message: "empty variable name",
 			Range: Range{
 				Start: start,
-				End:   Position{Line: line, Character: start.Character + utf8.RuneCountInString(s)},
+				End:   Position{Line: line, Character: start.Character + lsppos.UTF16Len(s)},
 			},
 		}
 	}
@@ -118,7 +118,7 @@ func parseSingleVariable(s string, start Position, line int) (VariableExpr, *Par
 	// Wildcard suffix: COLLECTION* is equivalent to COLLECTION:*.
 	if pos < len(s) && s[pos] == '*' {
 		expr.Key = "*"
-		endChar := start.Character + utf8.RuneCountInString(s)
+		endChar := start.Character + lsppos.UTF16Len(s)
 		expr.Range = Range{
 			Start: start,
 			End:   Position{Line: line, Character: endChar},
@@ -144,7 +144,7 @@ func parseSingleVariable(s string, start Position, line int) (VariableExpr, *Par
 				Message: `unclosed regex in variable key: missing closing /`,
 				Range: Range{
 					Start: start,
-					End:   Position{Line: line, Character: start.Character + utf8.RuneCountInString(s)},
+					End:   Position{Line: line, Character: start.Character + lsppos.UTF16Len(s)},
 				},
 			}
 		} else {
@@ -152,7 +152,7 @@ func parseSingleVariable(s string, start Position, line int) (VariableExpr, *Par
 		}
 	}
 
-	endChar := start.Character + utf8.RuneCountInString(s)
+	endChar := start.Character + lsppos.UTF16Len(s)
 	expr.Range = Range{
 		Start: start,
 		End:   Position{Line: line, Character: endChar},

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coraza-incubator/coraza-lsp/internal/definition"
 	"github.com/coraza-incubator/coraza-lsp/internal/formatting"
 	"github.com/coraza-incubator/coraza-lsp/internal/hover"
+	"github.com/coraza-incubator/coraza-lsp/internal/lsppos"
 	"github.com/coraza-incubator/coraza-lsp/internal/parser"
 	"github.com/coraza-incubator/coraza-lsp/internal/symbols"
 )
@@ -386,12 +387,15 @@ func (s *Server) completionHandler(ctx *glsp.Context, params *protocol.Completio
 	if line >= len(lines) {
 		return nil, nil
 	}
+	// params.Position.Character is a UTF-16 column. DetectContext and the line
+	// slicing below are byte-based, so map it to a byte offset within this line.
+	// (The AST position checks further down keep the UTF-16 column, since AST
+	// ranges are UTF-16 too.)
 	partialLine := lines[line]
-	if char <= len(partialLine) {
-		partialLine = partialLine[:char]
-	}
+	byteCol := lsppos.UTF16ColumnToByte(partialLine, char)
+	partialLine = partialLine[:byteCol]
 
-	compCtx, prefix := completion.DetectContext(partialLine, char)
+	compCtx, prefix := completion.DetectContext(partialLine, byteCol)
 
 	// For multi-line SecRules, physical continuation lines (e.g. "    phase:2,\")
 	// don't start with a directive keyword so DetectContext returns


### PR DESCRIPTION
LSP positions use **UTF-16 code units** for `character` (the default, universally-supported encoding). The parser emitted **rune** counts and some handlers indexed line text by **bytes** — three different units. For ASCII they agree; for BMP text (smart quotes, em dashes, accents, arrows, CJK — most of what an AI emits) rune count happens to equal UTF-16, so it looked fine. But **astral-plane characters (emoji 😀, math alphanumerics) are 1 rune yet 2 UTF-16 units**, so a diagnostic/hover/definition landed on the wrong column — we couldn't say *exactly* where a rule broke.

- New `internal/lsppos`: `UTF16Len`, `UTF16ColumnToByte`, `UTF16ColumnToRune`.
- Parser reports columns in UTF-16 code units (all column computations switched from rune counts). BMP-only tests unaffected (UTF-16 == rune there).
- Input side: completion maps the incoming UTF-16 column → byte offset before slicing; hover's `wordAtPos`/`macroVarAtPos` map it → rune index. AST position checks keep the UTF-16 column (AST ranges are UTF-16 now).
- Formatter's full-document edit end column is UTF-16, not a byte length.

No `positionEncoding` advertisement (glsp is 3.16) → clients use the UTF-16 default, which is exactly what we now produce. Regression tests use a real emoji to prove columns are exact for astral characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)