### PR TITLE
feat(vscode): Go to Rule by ID command

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -18,7 +18,10 @@ language server.
 - **Hover** — full markdown documentation for every language element.
 - **Go to definition** — jump from `skipAfter:MARKER` to `SecMarker MARKER`,
   or from `Include` to the included file.
-- **Document / workspace symbols** — navigate rules by id or message.
+- **Document / workspace symbols** — navigate rules by id, message or tag.
+- **Go to rule by ID** — run **Coraza: Go to Rule by ID** (Command Palette) and
+  type a rule id to jump straight to it. (Built on workspace symbols; open the
+  rule files, or set `"global": true` in `.coraza.json`, so they are indexed.)
 - **Formatting** — normalise whitespace and continuation lines on save.
 - **Quick-fixes** — add missing `id`, add `phase:2`, remove unknown directive.
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -72,6 +72,11 @@
         "command": "coraza-lsp.showOutputChannel",
         "title": "Show Output Channel",
         "category": "Coraza"
+      },
+      {
+        "command": "coraza-lsp.gotoRule",
+        "title": "Go to Rule by ID",
+        "category": "Coraza"
       }
     ],
     "configuration": {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -62,9 +62,73 @@ export function activate(context: vscode.ExtensionContext): { client: LanguageCl
     vscode.commands.registerCommand('coraza-lsp.showOutputChannel', () => {
       outputChannel?.show();
     }),
+
+    vscode.commands.registerCommand('coraza-lsp.gotoRule', gotoRuleById),
   );
 
   return { client };
+}
+
+// gotoRuleById prompts for a rule id and jumps to the matching SecRule, reusing
+// the language server's workspace-symbol index (rules are indexed by id). No
+// custom LSP request is needed — this drives the standard workspace symbol
+// provider the server already implements.
+async function gotoRuleById(preset?: string): Promise<void> {
+  const id =
+    preset ??
+    (await vscode.window.showInputBox({
+      title: 'Coraza: Go to Rule by ID',
+      prompt: 'Enter a SecRule id',
+      placeHolder: 'e.g. 942100',
+      validateInput: (v) => (/^\d+$/.test(v.trim()) ? undefined : 'Enter a numeric rule id'),
+    }));
+  if (!id) {
+    return;
+  }
+  const ruleId = id.trim();
+
+  const symbols =
+    (await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+      'vscode.executeWorkspaceSymbolProvider',
+      ruleId,
+    )) ?? [];
+
+  // The server labels rules as "<Directive> <id>" or "<Directive> <id>: <msg>".
+  // Match on the id token so a query like "42" doesn't jump to rule 9942100.
+  const matches = symbols.filter((s) => {
+    const parts = s.name.split(/\s+/);
+    const idTok = parts[1]?.replace(/:$/, '');
+    return idTok === ruleId;
+  });
+
+  if (matches.length === 0) {
+    vscode.window.showWarningMessage(
+      `No rule with id ${ruleId} found. Open the rule files (or set "global": true in .coraza.json) so they are indexed.`,
+    );
+    return;
+  }
+
+  const target =
+    matches.length === 1
+      ? matches[0]
+      : (
+          await vscode.window.showQuickPick(
+            matches.map((s) => ({
+              label: s.name,
+              description: vscode.workspace.asRelativePath(s.location.uri),
+              symbol: s,
+            })),
+            { title: `Multiple rules with id ${ruleId}` },
+          )
+        )?.symbol;
+  if (!target) {
+    return;
+  }
+
+  const doc = await vscode.workspace.openTextDocument(target.location.uri);
+  const editor = await vscode.window.showTextDocument(doc);
+  editor.selection = new vscode.Selection(target.location.range.start, target.location.range.start);
+  editor.revealRange(target.location.range, vscode.TextEditorRevealType.InCenter);
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
Adds a **Coraza: Go to Rule by ID** Command Palette command: type a rule id and jump straight to it.

**Does it need the LSP?** No new request — it reuses the server's existing `workspace/symbol` index (rules are indexed by id/msg/tag, fixed in #9). The command drives the standard `vscode.executeWorkspaceSymbolProvider`, matches on the id token (so "42" doesn't match rule 9942100), and shows a quick-pick when the id exists in multiple files. ("Go to Symbol in Workspace" / Ctrl+T already worked by id; this is the dedicated enter-id-and-go UX you asked for.)

TypeScript compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)