### PR TITLE
feat(config): declare custom operator/action/transformation names in .coraza.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Fields:
 | `filePatterns` | string[] | `["**/*.conf"]` | Files to treat as SecLang (combined with a SecLang-directive sniff). |
 | `ignore` | string[] | `["**/.git/**", "**/node_modules/**"]` | Globs excluded from indexing. |
 | `diagnostics` | map[string]string | `{}` | Per-code severity override: `error` / `warning` / `information` / `hint` / `off`. Keys are the diagnostic codes emitted by the server. |
+| `extraOperators` | string[] | `[]` | Plugin-registered operator names to treat as known so they aren't flagged unknown. May include a leading `@`. |
+| `extraActions` | string[] | `[]` | Plugin-registered action names to treat as known so they aren't flagged unknown. |
+| `extraTransformations` | string[] | `[]` | Plugin-registered transformation names to treat as known so they aren't flagged unknown. |
 
 The file is **hot-reloaded**: saving changes to `.coraza.json` re-applies the
 settings to every open document without restarting the editor.

--- a/internal/analysis/diagnostics.go
+++ b/internal/analysis/diagnostics.go
@@ -162,13 +162,13 @@ func Analyze(f *parser.File) []protocol_3_16.Diagnostic {
 // strictness when an entrypoint is configured.
 // This function is safe to call from multiple goroutines.
 func AnalyzeWith(f *parser.File, opts Options) []protocol_3_16.Diagnostic {
-	return opts.apply(analyzeRaw(f, nil))
+	return opts.apply(analyzeRaw(f, nil, opts))
 }
 
 // analyzeRaw is the original body of Analyze — it emits diagnostics without
 // any severity overrides applied. Kept as a discrete function so AnalyzeWith
 // can run severity remapping as a single post-processing pass.
-func analyzeRaw(f *parser.File, diags []protocol_3_16.Diagnostic) []protocol_3_16.Diagnostic {
+func analyzeRaw(f *parser.File, diags []protocol_3_16.Diagnostic, opts Options) []protocol_3_16.Diagnostic {
 
 	// Collect parse errors from the AST.
 	for _, pe := range f.Errors {
@@ -288,7 +288,7 @@ func analyzeRaw(f *parser.File, diags []protocol_3_16.Diagnostic) []protocol_3_1
 			lower := action.LowerName()
 
 			// Unknown action name.
-			if !knownActions[lower] {
+			if !knownActions[lower] && !opts.ExtraActions[lower] {
 				diags = append(diags, protocol_3_16.Diagnostic{
 					Range:    toProtocolRange(action.Range),
 					Severity: severityPtr(protocol_3_16.DiagnosticSeverityWarning),
@@ -326,7 +326,7 @@ func analyzeRaw(f *parser.File, diags []protocol_3_16.Diagnostic) []protocol_3_1
 						Code:     &protocol_3_16.IntegerOrString{Value: CodeMissingTransformation},
 						Message:  "t requires a transformation name (e.g. t:lowercase)",
 					})
-				} else if !knownTransformations[strings.ToLower(action.Value)] {
+				} else if !knownTransformations[strings.ToLower(action.Value)] && !opts.ExtraTransformations[strings.ToLower(action.Value)] {
 					// Unknown but syntactically valid — warn rather than error, because
 					// custom/vendor transformations not in the knowledge base may exist.
 					diags = append(diags, protocol_3_16.Diagnostic{
@@ -357,7 +357,7 @@ func analyzeRaw(f *parser.File, diags []protocol_3_16.Diagnostic) []protocol_3_1
 
 		// Validate operator name.
 		if rule.Operator != nil && rule.Operator.Name != "" {
-			if !knownOperators[strings.ToLower(rule.Operator.Name)] {
+			if !knownOperators[strings.ToLower(rule.Operator.Name)] && !opts.ExtraOperators[strings.ToLower(rule.Operator.Name)] {
 				diags = append(diags, protocol_3_16.Diagnostic{
 					Range:    toProtocolRange(rule.Operator.NameRange),
 					Severity: severityPtr(protocol_3_16.DiagnosticSeverityWarning),

--- a/internal/analysis/options.go
+++ b/internal/analysis/options.go
@@ -28,6 +28,27 @@ type Options struct {
 	// because pkg/lsp populates it; reading it is a future enhancement. Do not
 	// rely on it to change diagnostic severities today.
 	EntrypointAware bool
+
+	// ExtraOperators is the set of additional operator names (from
+	// `.coraza.json`'s `extraOperators`) that the analyser should treat as
+	// known, suppressing unknown-operator diagnostics for plugin-registered
+	// operators. Keys are normalised: lowercased with any leading '@' stripped
+	// (operator names in the AST carry no leading '@'). A nil map is safe to
+	// index and simply means "no extras".
+	ExtraOperators map[string]bool
+
+	// ExtraActions is the set of additional action names (from `.coraza.json`'s
+	// `extraActions`) that the analyser should treat as known, suppressing
+	// unknown-action diagnostics for plugin-registered actions. Keys are
+	// lowercased. A nil map is safe to index.
+	ExtraActions map[string]bool
+
+	// ExtraTransformations is the set of additional transformation names (from
+	// `.coraza.json`'s `extraTransformations`) that the analyser should treat
+	// as known, suppressing unknown-transformation diagnostics for plugin-
+	// registered transformations. Keys are lowercased. A nil map is safe to
+	// index.
+	ExtraTransformations map[string]bool
 }
 
 // DefaultOptions returns an Options value equivalent to "no user config".

--- a/internal/analysis/options_test.go
+++ b/internal/analysis/options_test.go
@@ -101,6 +101,56 @@ func TestApply_DoesNotAliasInput(t *testing.T) {
 	assert.Equal(t, CodeMissingPhase, co)
 }
 
+// TestAnalyzeWith_ExtraOperators verifies a plugin-registered operator name
+// declared via Options.ExtraOperators is not flagged unknown (case-insensitive),
+// while an undeclared operator still is.
+func TestAnalyzeWith_ExtraOperators(t *testing.T) {
+	t.Parallel()
+	opts := Options{ExtraOperators: map[string]bool{"mycustomop": true}}
+
+	// Declared (case-insensitive) operator: no unknown-operator diagnostic.
+	f := parser.Parse("", `SecRule ARGS "@myCustomOp foo" "id:1,phase:2,deny"`)
+	assert.NotContains(t, diagCodes(AnalyzeWith(f, opts)), CodeUnknownOperator,
+		"declared extra operator must not be flagged unknown")
+
+	// Undeclared operator: still flagged.
+	g := parser.Parse("", `SecRule ARGS "@nopeOp foo" "id:2,phase:2,deny"`)
+	assert.Contains(t, diagCodes(AnalyzeWith(g, opts)), CodeUnknownOperator,
+		"undeclared operator must still be flagged unknown")
+}
+
+// TestAnalyzeWith_ExtraActions verifies a plugin-registered action name declared
+// via Options.ExtraActions is not flagged unknown (case-insensitive), while an
+// undeclared action still is.
+func TestAnalyzeWith_ExtraActions(t *testing.T) {
+	t.Parallel()
+	opts := Options{ExtraActions: map[string]bool{"mycustomaction": true}}
+
+	f := parser.Parse("", `SecRule ARGS "@rx x" "id:1,phase:2,myCustomAction"`)
+	assert.NotContains(t, diagCodes(AnalyzeWith(f, opts)), CodeUnknownAction,
+		"declared extra action must not be flagged unknown")
+
+	g := parser.Parse("", `SecRule ARGS "@rx x" "id:2,phase:2,nopeAction"`)
+	assert.Contains(t, diagCodes(AnalyzeWith(g, opts)), CodeUnknownAction,
+		"undeclared action must still be flagged unknown")
+}
+
+// TestAnalyzeWith_ExtraTransformations verifies a plugin-registered
+// transformation name declared via Options.ExtraTransformations is not flagged
+// unknown (case-insensitive), while an undeclared one still is.
+func TestAnalyzeWith_ExtraTransformations(t *testing.T) {
+	t.Parallel()
+	opts := Options{ExtraTransformations: map[string]bool{"mycustomtransform": true}}
+
+	f := parser.Parse("", `SecRule ARGS "@rx x" "id:1,phase:2,deny,t:myCustomTransform"`)
+	assert.NotContains(t, diagCodes(AnalyzeWith(f, opts)), CodeUnknownTransformation,
+		"declared extra transformation must not be flagged unknown")
+
+	g := parser.Parse("", `SecRule ARGS "@rx x" "id:2,phase:2,deny,t:nopeTransform"`)
+	assert.Contains(t, diagCodes(AnalyzeWith(g, opts)), CodeUnknownTransformation,
+		"undeclared transformation must still be flagged unknown")
+}
+
 // TestAnalyzeWith_NilOptionsMatchesAnalyze ensures AnalyzeWith with a zero
 // Options is byte-identical to Analyze.
 func TestAnalyzeWith_NilOptionsMatchesAnalyze(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,25 @@ type Config struct {
 	// Diagnostics maps diagnostic codes (e.g. "skipafter-not-found") to a
 	// severity override. Use "off" to suppress a diagnostic entirely.
 	Diagnostics map[string]Severity `json:"diagnostics,omitempty"`
+
+	// ExtraOperators are additional operator names that should be treated as
+	// known so the analyser stops flagging them as unknown. Use this for
+	// operators registered by a plugin that the LSP's built-in knowledge base
+	// does not ship. Names may be written with or without a leading '@'
+	// (e.g. "@detectXSS" and "detectXSS" are equivalent).
+	ExtraOperators []string `json:"extraOperators,omitempty"`
+
+	// ExtraActions are additional action names that should be treated as known
+	// so the analyser stops flagging them as unknown. Use this for actions
+	// registered by a plugin that the LSP's built-in knowledge base does not
+	// ship.
+	ExtraActions []string `json:"extraActions,omitempty"`
+
+	// ExtraTransformations are additional transformation names that should be
+	// treated as known so the analyser stops flagging them as unknown. Use this
+	// for transformations registered by a plugin that the LSP's built-in
+	// knowledge base does not ship.
+	ExtraTransformations []string `json:"extraTransformations,omitempty"`
 }
 
 // Default returns a Config populated with the shipped defaults.
@@ -111,6 +130,15 @@ func (c *Config) Merge(defaults Config) {
 	}
 	if c.Ignore == nil {
 		c.Ignore = append([]string(nil), defaults.Ignore...)
+	}
+	if c.ExtraOperators == nil {
+		c.ExtraOperators = append([]string(nil), defaults.ExtraOperators...)
+	}
+	if c.ExtraActions == nil {
+		c.ExtraActions = append([]string(nil), defaults.ExtraActions...)
+	}
+	if c.ExtraTransformations == nil {
+		c.ExtraTransformations = append([]string(nil), defaults.ExtraTransformations...)
 	}
 	if c.Diagnostics == nil {
 		c.Diagnostics = map[string]Severity{}
@@ -326,6 +354,15 @@ const Template = `{
   "ignore": ["**/.git/**", "**/node_modules/**"],
 
   "//": "Override diagnostic severities per code. Valid values: error, warning, information, hint, off. Codes match the 'code' field in LSP diagnostics.",
-  "diagnostics": {}
+  "diagnostics": {},
+
+  "//": "Extra operator names registered by plugins (with or without @). Suppresses unknown-operator diagnostics.",
+  "extraOperators": [],
+
+  "//": "Extra action names registered by plugins. Suppresses unknown-action diagnostics.",
+  "extraActions": [],
+
+  "//": "Extra transformation names registered by plugins. Suppresses unknown-transformation diagnostics.",
+  "extraTransformations": []
 }
 `

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,6 +133,47 @@ func TestMerge_ExplicitEmptyIgnore(t *testing.T) {
 	assert.Equal(t, []string{}, file.Ignore)
 }
 
+func TestLoad_ExtraKnownNames(t *testing.T) {
+	t.Parallel()
+	src := `{
+		"extraOperators": ["@detectXSS", "myCustomOp"],
+		"extraActions": ["myCustomAction"],
+		"extraTransformations": ["myCustomTransform"]
+	}`
+	path := writeTemp(t, ".coraza.json", src)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, []string{"@detectXSS", "myCustomOp"}, cfg.ExtraOperators)
+	assert.Equal(t, []string{"myCustomAction"}, cfg.ExtraActions)
+	assert.Equal(t, []string{"myCustomTransform"}, cfg.ExtraTransformations)
+}
+
+func TestMerge_ExtraKnownNamesNotAliased(t *testing.T) {
+	t.Parallel()
+	// Defaults carry Extra* slices; Merge must copy (not alias) them so mutating
+	// the merged config's backing array cannot corrupt the shared defaults.
+	defaults := Default()
+	defaults.ExtraOperators = []string{"defaultOp"}
+	defaults.ExtraActions = []string{"defaultAction"}
+	defaults.ExtraTransformations = []string{"defaultTransform"}
+
+	file := Config{}
+	file.Merge(defaults)
+
+	require.Equal(t, []string{"defaultOp"}, file.ExtraOperators)
+	require.Equal(t, []string{"defaultAction"}, file.ExtraActions)
+	require.Equal(t, []string{"defaultTransform"}, file.ExtraTransformations)
+
+	// Mutate the merged config's slices; the defaults must be unaffected.
+	file.ExtraOperators[0] = "mutated"
+	file.ExtraActions[0] = "mutated"
+	file.ExtraTransformations[0] = "mutated"
+	assert.Equal(t, "defaultOp", defaults.ExtraOperators[0], "merge must not alias ExtraOperators")
+	assert.Equal(t, "defaultAction", defaults.ExtraActions[0], "merge must not alias ExtraActions")
+	assert.Equal(t, "defaultTransform", defaults.ExtraTransformations[0], "merge must not alias ExtraTransformations")
+}
+
 func TestValidate_UnknownDiagnosticCode(t *testing.T) {
 	t.Parallel()
 	RegisterDiagnosticCodes("missing-id", "invalid-phase")

--- a/pkg/lsp/config.go
+++ b/pkg/lsp/config.go
@@ -105,7 +105,9 @@ func (s *Server) analysisOptions() analysis.Options {
 }
 
 func optionsFromConfig(cfg config.Config) analysis.Options {
-	if len(cfg.Diagnostics) == 0 && !cfg.Global && cfg.Entrypoint == "" {
+	if len(cfg.Diagnostics) == 0 && !cfg.Global && cfg.Entrypoint == "" &&
+		len(cfg.ExtraOperators) == 0 && len(cfg.ExtraActions) == 0 &&
+		len(cfg.ExtraTransformations) == 0 {
 		return analysis.DefaultOptions()
 	}
 	return analysis.Options{
@@ -117,7 +119,31 @@ func optionsFromConfig(cfg config.Config) analysis.Options {
 		// plain non-empty check so the field reflects intent without implying
 		// behaviour that doesn't exist.
 		EntrypointAware: cfg.Entrypoint != "",
+		// Operator names in the AST carry no leading '@', so strip a single one
+		// from each configured name before normalising.
+		ExtraOperators:       normalizedSet(cfg.ExtraOperators, true),
+		ExtraActions:         normalizedSet(cfg.ExtraActions, false),
+		ExtraTransformations: normalizedSet(cfg.ExtraTransformations, false),
 	}
+}
+
+// normalizedSet builds a lowercased lookup set from names. When stripAt is
+// true a single leading '@' is removed from each name first (operator names in
+// the AST never carry the '@', so `@detectXSS` and `detectXSS` both map to
+// `detectxss`). Returns nil for an empty input so the resulting Options field
+// stays nil (indexing a nil map is safe and simply yields false).
+func normalizedSet(names []string, stripAt bool) map[string]bool {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		if stripAt {
+			n = strings.TrimPrefix(n, "@")
+		}
+		set[strings.ToLower(n)] = true
+	}
+	return set
 }
 
 // WatchConfig starts a background goroutine that watches the config file for

--- a/pkg/lsp/config_test.go
+++ b/pkg/lsp/config_test.go
@@ -68,6 +68,40 @@ func TestLoadConfig_AppliesSeverityOverrides(t *testing.T) {
 	assert.Equal(t, config.SeverityOff, opts.SeverityOverrides["unknown-variable"])
 }
 
+func TestOptionsFromConfig_ExtraNamesNormalized(t *testing.T) {
+	t.Parallel()
+	cfg := config.Config{
+		ExtraOperators:       []string{"@detectXSS", "MyCustomOp"},
+		ExtraActions:         []string{"MyAction"},
+		ExtraTransformations: []string{"MyTransform"},
+	}
+	opts := optionsFromConfig(cfg)
+
+	// Operator names: leading '@' stripped and lowercased.
+	assert.Equal(t, map[string]bool{"detectxss": true, "mycustomop": true}, opts.ExtraOperators)
+	// A name written without '@' still resolves.
+	assert.True(t, opts.ExtraOperators["mycustomop"])
+	// Actions and transformations: just lowercased.
+	assert.Equal(t, map[string]bool{"myaction": true}, opts.ExtraActions)
+	assert.Equal(t, map[string]bool{"mytransform": true}, opts.ExtraTransformations)
+}
+
+func TestOptionsFromConfig_OnlyExtrasStillBuildsOptions(t *testing.T) {
+	t.Parallel()
+	// No diagnostics/global/entrypoint — only Extra* set. The early-return guard
+	// must NOT fire, so the Extra* maps are populated rather than dropped.
+	cfg := config.Config{ExtraOperators: []string{"myop"}}
+	opts := optionsFromConfig(cfg)
+
+	assert.NotEqual(t, analysis.DefaultOptions(), opts, "extras-only config must produce non-default options")
+	assert.True(t, opts.ExtraOperators["myop"])
+}
+
+func TestOptionsFromConfig_EmptyIsDefault(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, analysis.DefaultOptions(), optionsFromConfig(config.Config{}))
+}
+
 func TestLoadConfig_ValidationErrorSurfaced(t *testing.T) {
 	t.Parallel()
 	s := newTestServer()

--- a/schema/coraza.schema.json
+++ b/schema/coraza.schema.json
@@ -49,6 +49,21 @@
           "unknown-variable": "off"
         }
       ]
+    },
+    "extraOperators": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Additional operator names registered by plugins that should be treated as known, so they are not flagged as unknown operators. Names may be written with or without a leading '@'."
+    },
+    "extraActions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Additional action names registered by plugins that should be treated as known, so they are not flagged as unknown actions."
+    },
+    "extraTransformations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Additional transformation names registered by plugins that should be treated as known, so they are not flagged as unknown transformations."
     }
   }
 }


### PR DESCRIPTION
**Operate better with plugins.** Coraza/CRS plugins register their own operators, actions and transformations; the analyzer flagged them as `unknown-operator` / `unknown-action` / `unknown-transformation` (false positives). Now you can declare them in `.coraza.json`:

```json
{
  "extraOperators":       ["@detectXSS2", "myPluginOp"],
  "extraActions":         ["myPluginAction"],
  "extraTransformations": ["myPluginTransform"]
}
```

- Additive (don't replace the built-ins), matched **case-insensitively**; operators may be written **with or without `@`**.
- Declared names suppress the matching unknown-X diagnostic; undeclared ones still fire.
- **Hot-reloaded** and **editor-agnostic** — works in any LSP client (it's the project config, the same `.coraza.json` VS Code already reads). A dedicated VS Code *settings*-UI mirror could be a thin follow-up if wanted.

Plumbed through `analysis.Options` into the three unknown checks; schema, `coraza-lsp init` template and README updated. Tests: parsing, non-aliasing Merge, `@`-strip+lowercase normalization, widened `optionsFromConfig` guard, and suppression vs. still-firing behavior. 16 packages green under `-race`; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)