### PR TITLE
feat(vscode): native settings for extra operators/actions/transformations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "cmd/**"
       - "internal/**"
+      - "pkg/**"
       - "test/**"
       - "go.mod"
       - "go.sum"
@@ -15,6 +16,7 @@ on:
     paths:
       - "cmd/**"
       - "internal/**"
+      - "pkg/**"
       - "test/**"
       - "go.mod"
       - "go.sum"

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -63,6 +63,16 @@ The extension needs the `coraza-lsp` binary on your `$PATH`. Options:
 |---|---|---|
 | `coraza-lsp.serverPath` | `coraza-lsp` | Path to the language-server binary. |
 | `coraza-lsp.trace.server` | `off` | LSP trace level (`off` / `messages` / `verbose`). |
+| `coraza-lsp.extraOperators` | `[]` | Extra operator names registered by Coraza / CRS plugins, treated as known so they aren't flagged unknown. Names may include a leading `@`. |
+| `coraza-lsp.extraActions` | `[]` | Extra action names registered by plugins, treated as known. |
+| `coraza-lsp.extraTransformations` | `[]` | Extra transformation names registered by plugins, treated as known. |
+
+The three `extra*` settings declare custom-knowledge names so the analyser
+does not report them as unknown. They **layer on top of** (are UNIONed with)
+the matching `extraOperators` / `extraActions` / `extraTransformations` fields
+in your workspace `.coraza.json` — declaring a name in either place is enough.
+Because these are passed to the server only at startup, the language server is
+**restarted automatically** when you change any of them.
 
 ## Multi-file rule sets
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -96,6 +96,30 @@
           ],
           "default": "off",
           "description": "Trace LSP communication between VS Code and the language server."
+        },
+        "coraza-lsp.extraOperators": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Extra operator names registered by Coraza / CRS plugins, treated as known so they aren't flagged as unknown. These are UNIONed with the `extraOperators` field of `.coraza.json`. Names may include a leading `@`. Changing this restarts the language server."
+        },
+        "coraza-lsp.extraActions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Extra action names registered by Coraza / CRS plugins, treated as known so they aren't flagged as unknown. These are UNIONed with the `extraActions` field of `.coraza.json`. Changing this restarts the language server."
+        },
+        "coraza-lsp.extraTransformations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Extra transformation names registered by Coraza / CRS plugins, treated as known so they aren't flagged as unknown. These are UNIONed with the `extraTransformations` field of `.coraza.json`. Changing this restarts the language server."
         }
       }
     }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -32,6 +32,15 @@ function createClient(): LanguageClient {
     synchronize: {
       fileEvents: vscode.workspace.createFileSystemWatcher('**/*.conf'),
     },
+    // Custom-knowledge extras passed to the server at initialize. The server
+    // UNIONs these with the extra* fields of `.coraza.json`. Because
+    // initializationOptions are only read once per session, activate() restarts
+    // the server when any of these settings change.
+    initializationOptions: {
+      extraOperators: config.get<string[]>('extraOperators') ?? [],
+      extraActions: config.get<string[]>('extraActions') ?? [],
+      extraTransformations: config.get<string[]>('extraTransformations') ?? [],
+    },
     outputChannel,
     traceOutputChannel,
   };
@@ -64,6 +73,18 @@ export function activate(context: vscode.ExtensionContext): { client: LanguageCl
     }),
 
     vscode.commands.registerCommand('coraza-lsp.gotoRule', gotoRuleById),
+
+    // initializationOptions (the extra* knowledge sets) are only read when the
+    // server starts, so restart it when any of those settings change.
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (
+        e.affectsConfiguration('coraza-lsp.extraOperators') ||
+        e.affectsConfiguration('coraza-lsp.extraActions') ||
+        e.affectsConfiguration('coraza-lsp.extraTransformations')
+      ) {
+        void vscode.commands.executeCommand('coraza-lsp.restartServer');
+      }
+    }),
   );
 
   return { client };

--- a/pkg/lsp/config.go
+++ b/pkg/lsp/config.go
@@ -28,6 +28,15 @@ type configState struct {
 	opts    analysis.Options
 	watcher *fsnotify.Watcher // nil until WatchConfig has been called
 	stop    chan struct{}     // closed to stop the watcher goroutine
+
+	// clientExtra* hold the custom-knowledge extras declared by the editor
+	// client via LSP initializationOptions (see handler.go). They are stored as
+	// normalized lookup sets (lowercased; operators have a leading '@' stripped)
+	// and UNIONed with the `.coraza.json`-derived extras in analysisOptions().
+	// Guarded by mu like the rest of configState.
+	clientExtraOperators       map[string]bool
+	clientExtraActions         map[string]bool
+	clientExtraTransformations map[string]bool
 }
 
 // LoadConfig discovers and loads `.coraza.json` for the given workspace root.
@@ -96,12 +105,58 @@ func (s *Server) configRoot() string {
 	return s.cfgState.root
 }
 
+// setClientExtra records the custom-knowledge extras declared by the editor
+// client (via LSP initializationOptions). The names are normalized into lookup
+// sets — operator names have a single leading '@' stripped, all are lowercased
+// — and stored under the config lock. These are UNIONed with the
+// `.coraza.json`-derived extras by analysisOptions(); they never mutate the
+// loaded config.
+func (s *Server) setClientExtra(operators, actions, transformations []string) {
+	ops := normalizedSet(operators, true)
+	acts := normalizedSet(actions, false)
+	tfs := normalizedSet(transformations, false)
+
+	s.cfgState.mu.Lock()
+	s.cfgState.clientExtraOperators = ops
+	s.cfgState.clientExtraActions = acts
+	s.cfgState.clientExtraTransformations = tfs
+	s.cfgState.mu.Unlock()
+}
+
 // analysisOptions returns the derived analysis.Options. Used on every
 // analyse call so severity overrides stay in sync with config edits.
+//
+// The Extra* knowledge sets returned are the UNION of the `.coraza.json`-derived
+// extras (cfgState.opts) and the client-declared extras (cfgState.clientExtra*).
+// The merge builds fresh maps so cfgState.opts' own maps are never mutated; an
+// empty union stays nil (a nil map indexes as false, which the analyser relies
+// on).
 func (s *Server) analysisOptions() analysis.Options {
 	s.cfgState.mu.RLock()
 	defer s.cfgState.mu.RUnlock()
-	return s.cfgState.opts
+
+	out := s.cfgState.opts
+	out.ExtraOperators = unionSets(s.cfgState.opts.ExtraOperators, s.cfgState.clientExtraOperators)
+	out.ExtraActions = unionSets(s.cfgState.opts.ExtraActions, s.cfgState.clientExtraActions)
+	out.ExtraTransformations = unionSets(s.cfgState.opts.ExtraTransformations, s.cfgState.clientExtraTransformations)
+	return out
+}
+
+// unionSets returns a fresh set containing every key present in a or b, leaving
+// the inputs untouched. Returns nil when both inputs are empty so the resulting
+// Options field stays nil.
+func unionSets(a, b map[string]bool) map[string]bool {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(a)+len(b))
+	for k := range a {
+		out[k] = true
+	}
+	for k := range b {
+		out[k] = true
+	}
+	return out
 }
 
 func optionsFromConfig(cfg config.Config) analysis.Options {

--- a/pkg/lsp/config_test.go
+++ b/pkg/lsp/config_test.go
@@ -231,3 +231,129 @@ func TestUriToPath(t *testing.T) {
 		})
 	}
 }
+
+// --- client-declared extras (LSP initializationOptions) ---------------------
+
+// TestSetClientExtra_NormalizedIntoOptions verifies that extras declared by the
+// editor client are normalized (operator '@' stripped, all lowercased) and
+// surface through analysisOptions().
+func TestSetClientExtra_NormalizedIntoOptions(t *testing.T) {
+	t.Parallel()
+	s := newTestServer()
+
+	s.setClientExtra(
+		[]string{"@myOp"},
+		[]string{"MyAction"},
+		[]string{"MyTransform"},
+	)
+
+	opts := s.analysisOptions()
+	assert.True(t, opts.ExtraOperators["myop"], "operator '@myOp' should normalize to 'myop'")
+	assert.True(t, opts.ExtraActions["myaction"])
+	assert.True(t, opts.ExtraTransformations["mytransform"])
+}
+
+// TestAnalysisOptions_UnionsConfigAndClientExtras verifies that the extras from
+// `.coraza.json` and from the client are UNIONed, not replaced, and that the
+// merge does not mutate the loaded config's own maps.
+func TestAnalysisOptions_UnionsConfigAndClientExtras(t *testing.T) {
+	t.Parallel()
+	s := newTestServer()
+	dir := t.TempDir()
+	writeConfig(t, dir, `{
+		"extraOperators": ["@fromConfig"],
+		"extraActions": ["actFromConfig"],
+		"extraTransformations": ["tfFromConfig"]
+	}`)
+
+	var errs []string
+	s.LoadConfig(dir, func(msg string) { errs = append(errs, msg) })
+	assert.Empty(t, errs)
+
+	s.setClientExtra(
+		[]string{"@fromClient"},
+		[]string{"actFromClient"},
+		[]string{"tfFromClient"},
+	)
+
+	opts := s.analysisOptions()
+	// Operators: both config- and client-declared present.
+	assert.True(t, opts.ExtraOperators["fromconfig"])
+	assert.True(t, opts.ExtraOperators["fromclient"])
+	// Actions: union.
+	assert.True(t, opts.ExtraActions["actfromconfig"])
+	assert.True(t, opts.ExtraActions["actfromclient"])
+	// Transformations: union.
+	assert.True(t, opts.ExtraTransformations["tffromconfig"])
+	assert.True(t, opts.ExtraTransformations["tffromclient"])
+
+	// The union must not have mutated cfgState.opts' own maps.
+	s.cfgState.mu.RLock()
+	base := s.cfgState.opts.ExtraOperators
+	s.cfgState.mu.RUnlock()
+	assert.Equal(t, map[string]bool{"fromconfig": true}, base,
+		"config-derived ExtraOperators must not be mutated by the union")
+}
+
+// TestAnalysisOptions_NoExtrasStaysNil verifies an empty union leaves the
+// Extra* fields nil (so they index as false in the analyser).
+func TestAnalysisOptions_NoExtrasStaysNil(t *testing.T) {
+	t.Parallel()
+	s := newTestServer()
+	dir := t.TempDir()
+	s.LoadConfig(dir, nil)
+	s.setClientExtra(nil, nil, nil)
+
+	opts := s.analysisOptions()
+	assert.Nil(t, opts.ExtraOperators)
+	assert.Nil(t, opts.ExtraActions)
+	assert.Nil(t, opts.ExtraTransformations)
+}
+
+// TestStringSliceFromAny covers the JSON-decode helper used to parse
+// initializationOptions.
+func TestStringSliceFromAny(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"a", "b"}, stringSliceFromAny([]any{"a", "b"}))
+	// Non-string elements are filtered out.
+	assert.Equal(t, []string{"a"}, stringSliceFromAny([]any{"a", 1, true, nil}))
+	// An array with no strings yields nil.
+	assert.Nil(t, stringSliceFromAny([]any{1, 2}))
+	// Non-array inputs yield nil.
+	assert.Nil(t, stringSliceFromAny("not-an-array"))
+	assert.Nil(t, stringSliceFromAny(map[string]any{"x": "y"}))
+	assert.Nil(t, stringSliceFromAny(nil))
+}
+
+// TestParseClientExtras covers the initializationOptions object parser.
+func TestParseClientExtras(t *testing.T) {
+	t.Parallel()
+
+	// nil / wrong-typed InitializationOptions must be safe (no extras).
+	ops, acts, tfs := parseClientExtras(nil)
+	assert.Nil(t, ops)
+	assert.Nil(t, acts)
+	assert.Nil(t, tfs)
+
+	ops, acts, tfs = parseClientExtras("garbage")
+	assert.Nil(t, ops)
+	assert.Nil(t, acts)
+	assert.Nil(t, tfs)
+
+	// A well-formed object with all three keys.
+	ops, acts, tfs = parseClientExtras(map[string]any{
+		"extraOperators":       []any{"@myOp"},
+		"extraActions":         []any{"myAct"},
+		"extraTransformations": []any{"myTf"},
+	})
+	assert.Equal(t, []string{"@myOp"}, ops)
+	assert.Equal(t, []string{"myAct"}, acts)
+	assert.Equal(t, []string{"myTf"}, tfs)
+
+	// Missing keys yield nil for those.
+	ops, acts, tfs = parseClientExtras(map[string]any{"extraActions": []any{"only"}})
+	assert.Nil(t, ops)
+	assert.Equal(t, []string{"only"}, acts)
+	assert.Nil(t, tfs)
+}

--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -223,6 +223,15 @@ func (s *Server) initialize(version string) protocol.InitializeFunc {
 			})
 		}
 		s.LoadConfig(root, showError)
+
+		// Layer the client-declared custom-knowledge extras on top of
+		// `.coraza.json`. params.InitializationOptions is `any`; we expect a
+		// JSON object with optional "extraOperators"/"extraActions"/
+		// "extraTransformations" string arrays. Anything missing or wrong-typed
+		// is ignored (no extras) — never a panic.
+		extraOps, extraActs, extraTfs := parseClientExtras(params.InitializationOptions)
+		s.setClientExtra(extraOps, extraActs, extraTfs)
+
 		if err := s.WatchConfig(s.onConfigChange, showError); err != nil {
 			showError(fmt.Sprintf("coraza-lsp: config watcher disabled: %v", err))
 		}
@@ -296,6 +305,38 @@ func workspaceRoot(params *protocol.InitializeParams) string {
 		return uriToPath(string(*params.RootURI))
 	}
 	return "."
+}
+
+// parseClientExtras pulls the custom-knowledge extras from the LSP
+// initializationOptions blob. The blob is `any`; only a map[string]any with
+// the three known keys (each a JSON string array) yields values. Missing,
+// nil, or wrong-typed input yields nil slices — callers treat that as "no
+// extras". Defensive by design: a hostile/garbled client must not panic.
+func parseClientExtras(v any) (operators, actions, transformations []string) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, nil, nil
+	}
+	return stringSliceFromAny(m["extraOperators"]),
+		stringSliceFromAny(m["extraActions"]),
+		stringSliceFromAny(m["extraTransformations"])
+}
+
+// stringSliceFromAny converts a JSON-decoded value into a []string. It returns
+// nil unless v is a []any; non-string elements are filtered out. A []any with
+// no strings yields nil.
+func stringSliceFromAny(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // uriToPath converts a file:// URI to an OS path (Windows drive letters and


### PR DESCRIPTION
Exposes the custom-knowledge feature (PR #19) as **native VS Code settings**, in addition to `.coraza.json`:

```jsonc
"coraza-lsp.extraOperators":       ["@detectXSS2"],
"coraza-lsp.extraActions":         ["myPluginAction"],
"coraza-lsp.extraTransformations": ["myPluginTransform"]
```

- Passed to the server via LSP **`initializationOptions`** and **UNIONed** with `.coraza.json`'s `extra*` (both sources are additive).
- Server parses `params.InitializationOptions` defensively and `analysisOptions()` merges client + config extras without mutating shared maps.
- The extension restarts the server when any of the three settings change (so edits take effect live).

gofmt/vet clean; 16 packages green under `-race` (new tests: normalization, union/no-mutation, `stringSliceFromAny`, `parseClientExtras`); `tsc` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)