### PR TITLE
fix(vfs): slash-canonical workspace paths (Windows in-memory FS)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -274,21 +275,25 @@ func Discover(start string) string {
 }
 
 // DiscoverFS walks from start up to the filesystem root looking for a
-// DefaultFilename. Returns the absolute path to the first one found, or ""
-// if none exists. start is resolved via filepath.Abs first (a no-op for paths
-// that are already absolute, including the synthetic roots embedders typically
-// pass to MemFS).
+// DefaultFilename. Returns the path to the first one found, or "" if none.
+//
+// Paths are handled SLASH-canonically (via path, not filepath): the VFS
+// abstraction is slash-based — an in-memory MemFS is keyed with "/" — and
+// os.* calls accept forward slashes on Windows too, so a single slash form
+// works for both the real-disk and in-memory implementations. Using filepath
+// here would prepend a drive letter to a synthetic root like "/policy" on
+// Windows (via filepath.Abs) and miss the slash-keyed MemFS entirely.
 func DiscoverFS(filesys vfs.FileSystem, start string) string {
-	dir, err := filepath.Abs(start)
-	if err != nil {
-		dir = start
+	if start == "" {
+		return ""
 	}
+	dir := path.Clean(filepath.ToSlash(start))
 	for {
-		candidate := filepath.Join(dir, DefaultFilename)
+		candidate := path.Join(dir, DefaultFilename)
 		if info, err := filesys.Stat(candidate); err == nil && !info.IsDir() {
 			return candidate
 		}
-		parent := filepath.Dir(dir)
+		parent := path.Dir(dir)
 		if parent == dir {
 			return ""
 		}

--- a/pkg/lsp/embed_test.go
+++ b/pkg/lsp/embed_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -25,14 +24,6 @@ import (
 // and OS-disk isolation all behave as the embedding contract promises.
 func TestEmbed_NewWithMemFS_DoesNotTouchDisk(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == "windows" {
-		// The in-memory MemFS is keyed with slash paths ("/policy/..."), but on
-		// Windows the workspace discovery resolves the root with filepath.Abs,
-		// which prepends a drive letter (C:\policy). Making the VFS fully
-		// slash-canonical for the in-memory-embedder case on Windows is tracked
-		// separately; the real-disk LSP path is unaffected.
-		t.Skip("MemFS embedder + Windows drive-letter paths — tracked separately")
-	}
 
 	// A recording FileSystem that wraps MemFS and remembers every path the
 	// LSP asked about. If the LSP ever tries to read something outside this

--- a/pkg/lsp/workspace.go
+++ b/pkg/lsp/workspace.go
@@ -100,11 +100,13 @@ func matchesAny(path string, globs []string, root string) bool {
 	if len(globs) == 0 {
 		return false
 	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		rel = path
-	}
-	rel = filepath.ToSlash(rel)
+	// Compute the slash-relative path without filepath.Rel: the VFS is
+	// slash-canonical (MemFS keys with "/") and on Windows the real walk yields
+	// backslash paths, so normalise both to slash and trim the root prefix.
+	// filepath.Rel mis-handles slash-rooted synthetic paths ("/policy/...") on
+	// Windows (it assumes OS semantics / a volume).
+	sroot := strings.TrimSuffix(filepath.ToSlash(root), "/")
+	rel := strings.TrimPrefix(filepath.ToSlash(path), sroot+"/")
 	base := filepath.ToSlash(filepath.Base(path))
 	for _, glob := range globs {
 		g := filepath.ToSlash(glob)


### PR DESCRIPTION
Closes the last tracked Windows item. The VFS is slash-based (MemFS keys with `/`), but config discovery + the workspace index used `filepath`, whose Windows semantics broke the in-memory-embedder case: `DiscoverFS` ran `filepath.Abs("/policy")`→`C:\policy` (drive + backslashes), missing the slash-keyed MemFS, and `matchesAny` used `filepath.Rel` on slash-rooted synthetic paths. Since `os.*` accepts forward slashes on Windows too, handling VFS paths slash-canonically (`path`, not `filepath`) is correct for **both** the real-disk and in-memory implementations.

- `DiscoverFS`: `path.Clean/Join/Dir` (no `filepath.Abs` drive prefix).
- `matchesAny`: slash-relative via `ToSlash` + prefix-trim instead of `filepath.Rel`.
- **Un-skipped** `TestEmbed_NewWithMemFS_DoesNotTouchDisk` — runs on every OS now.

16 packages green under `-race` on Linux; Windows verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)